### PR TITLE
fix: OPFS への書き込みを確実にするための CHECKPOINT 追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,6 +122,15 @@ export default function App() {
     };
   }, []);
 
+  // OPFSに確実に書き込むためチェックポイントを実行
+  const checkpoint = async (conn: duckdb.AsyncDuckDBConnection) => {
+    try {
+      await conn.query(`CHECKPOINT;`);
+    } catch (e) {
+      console.warn("CHECKPOINT failed:", e);
+    }
+  };
+
   // DB → strokes を読み直し
   const reloadFromDB = async () => {
     if (!dbConn) return;
@@ -195,6 +204,7 @@ export default function App() {
       `);
     }
     await reloadFromDB();
+    await checkpoint(dbConn);
   };
 
   const handleClear = async () => {
@@ -204,6 +214,7 @@ export default function App() {
     }
     await dbConn.query(`DELETE FROM strokes_json;`);
     await reloadFromDB();
+    await checkpoint(dbConn);
   };
 
   const handleRefresh = async () => reloadFromDB();
@@ -248,6 +259,7 @@ export default function App() {
     await updJ.query(JSON.stringify(newPtsPx), strokeId);
     await updJ.close();
     await reloadFromDB();
+    await checkpoint(dbConn);
   };
 
   // ドラッグ終了時に DB に保存
@@ -277,6 +289,7 @@ export default function App() {
     }
 
     await reloadFromDB();
+    await checkpoint(dbConn);
   };
 
   return (


### PR DESCRIPTION
# fix: OPFS への書き込みを確実にするための CHECKPOINT 追加

## 問題の背景

OPFS による永続化を実装したが、ブラウザリロード後もデータがリセットされる問題があった。

## 調査で判明した根本原因

### 原因①: CHECKPOINT が呼ばれていない（このPRで修正）

DuckDB はデフォルトで **WAL（Write-Ahead Log）モード**で動作する。

```
INSERT/UPDATE → WAL（メモリ/OPFS） → 定期的に CHECKPOINT → メインDBファイル
```

ブラウザでページをリロードすると **DuckDB Worker が強制終了**されるため、WAL の内容がメインのOPFSファイルに書き込まれないまま消えてしまう。各書き込み操作後に明示的に `CHECKPOINT` を呼ぶことで、データをOPFSのメインファイルへ確実にフラッシュする。

### 原因②: 初回アクセス時に crossOriginIsolated が false（coi-serviceworker により自動解消）

DuckDB WASM の OPFS 実装は内部で `FileSystemSyncAccessHandle.createSyncAccessHandle()` を使用している。このAPIは `crossOriginIsolated === true` のWorkerコンテキストを要求する。

```
初回アクセス（SWなし）
  → crossOriginIsolated = false
  → createSyncAccessHandle() が例外をスロー
  → _db.open() が失敗 → インメモリにフォールバック
  → coi-serviceworker が SW をインストール → ページ自動リロード

2回目以降（SW有効）
  → crossOriginIsolated = true
  → OPFS が有効化 ✅
  → でも CHECKPOINT がないのでリロードでデータが消える ❌（このPRで修正）
```

つまり2つの問題が重なっており、初回リロード後のデータ消失はこのPRの CHECKPOINT 修正で解決する。

#### 調査の根拠（DuckDB WASM ソースより）

Worker 内の `prepareFileHandles` 実装：
```javascript
// _preparedHandles に OPFS ハンドルを保存（lazy に _files へ移動）
let d = await _.createSyncAccessHandle(); // ← ここで失敗する
return X._preparedHandles[n] = d, { path: n, handle: d, fromCached: !1 }
```

OPEN ハンドラ：
```javascript
case "OPEN": {
  let r = e.data.path;
  r != null && r.startsWith("opfs://") && (
    await this._bindings.prepareDBFileHandle(r, 3), // ← 内部で createSyncAccessHandle を呼ぶ
    e.data.useDirectIO = !0
  );
  this._bindings.open(e.data);
}
```

## 変更内容

`checkpoint()` ヘルパーを追加し、以下の全書き込み操作の後に呼び出す：

| 操作 | 変更箇所 |
|------|----------|
| ストローク追加 | `persistStroke` |
| 点の移動 | `updateStroke` |
| Undo | `handleUndo` |
| Clear | `handleClear` |

```typescript
const checkpoint = async (conn: duckdb.AsyncDuckDBConnection) => {
  try {
    await conn.query(`CHECKPOINT;`);
  } catch (e) {
    console.warn("CHECKPOINT failed:", e);
  }
};
```

## 確認方法

1. GitHub Pages にデプロイ後、ストロークを描画する
2. ブラウザのコンソールで `window.crossOriginIsolated` が `true` であることを確認
3. ページをリロードして描画が残っていることを確認
   - フッターに「💾 データ永続化中 (OPFS)」と表示されていれば OPFS 有効

> **補足**: `crossOriginIsolated` が `false` の場合は coi-serviceworker が正常動作していない。初回アクセス後に自動リロードされれば `true` になる。
