### PR TITLE
feat: add geometry measurement tools

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,20 +8,19 @@ import { Scene } from "./components/Scene";
 import { DrawingSurface } from "./components/DrawingSurface";
 import { MapView } from "./components/MapView";
 import { StrokeEditor } from "./components/StrokeEditor";
+import { getPolygonArea, getPolygonPerimeter, getPolylineLength, pointsEqual, type Point2D } from "./lib/geometry";
 
 // DuckDB への保存は px 座標（画面座標）で行います
 type GeometryType = "line" | "polygon";
 
-const toLineWKT = (ptsPx: [number, number][]) => {
+const toLineWKT = (ptsPx: Point2D[]) => {
   // 非数値/NaN を除外して WKT を生成
   const filtered = ptsPx.filter(([x, y]) => Number.isFinite(x) && Number.isFinite(y));
   const body = filtered.map(([x, y]) => `${x} ${y}`).join(", ");
   return `LINESTRING(${body})`;
 };
 
-const pointsEqual = ([ax, ay]: [number, number], [bx, by]: [number, number]) => ax === bx && ay === by;
-
-const toPolygonWKT = (ptsPx: [number, number][]) => {
+const toPolygonWKT = (ptsPx: Point2D[]) => {
   const filtered = ptsPx.filter(([x, y]) => Number.isFinite(x) && Number.isFinite(y));
   const closed =
     filtered.length > 0 && !pointsEqual(filtered[0], filtered[filtered.length - 1])
@@ -31,22 +30,21 @@ const toPolygonWKT = (ptsPx: [number, number][]) => {
   return `POLYGON((${body}))`;
 };
 
-const toWKT = (ptsPx: [number, number][], type: GeometryType) =>
-  type === "polygon" ? toPolygonWKT(ptsPx) : toLineWKT(ptsPx);
+const toWKT = (ptsPx: Point2D[], type: GeometryType) => (type === "polygon" ? toPolygonWKT(ptsPx) : toLineWKT(ptsPx));
 
 const parseGeometryFromGeoJSON = (
   gj: { type?: string; coordinates?: [number, number][] | [number, number][][] },
   type: GeometryType
-): [number, number][] => {
-  let coordinates: [number, number][];
+): Point2D[] => {
+  let coordinates: Point2D[];
   if (type === "polygon") {
     if (gj.type !== "Polygon" || !gj.coordinates) return [];
-    coordinates = gj.coordinates[0] as [number, number][];
+    coordinates = gj.coordinates[0] as Point2D[];
   } else {
     if (gj.type !== "LineString" || !gj.coordinates) return [];
-    coordinates = gj.coordinates as [number, number][];
+    coordinates = gj.coordinates as Point2D[];
   }
-  const points = coordinates.map((c) => [c[0], c[1]] as [number, number]);
+  const points = coordinates.map((c) => [c[0], c[1]] as Point2D);
   if (type === "polygon" && points.length > 1 && pointsEqual(points[0], points[points.length - 1])) {
     points.pop();
   }
@@ -57,26 +55,18 @@ const toStr = (v: unknown): string => (typeof v === "string" ? v : v == null ? "
 const toNum = (v: unknown): number => (typeof v === "number" ? v : Number(v));
 const toGeometryType = (v: unknown): GeometryType => (toStr(v) === "polygon" ? "polygon" : "line");
 
-const polygonArea = (ptsPx: [number, number][]) => {
-  let area = 0;
-  for (let i = 0; i < ptsPx.length; i++) {
-    const [x1, y1] = ptsPx[i];
-    const [x2, y2] = ptsPx[(i + 1) % ptsPx.length];
-    area += x1 * y2 - x2 * y1;
-  }
-  return Math.abs(area) / 2;
-};
-
 interface Stroke {
   id: string;
   color: string;
   width: number; // px 単位
-  ptsPx: [number, number][]; // DB は px 座標で保持
+  ptsPx: Point2D[]; // DB は px 座標で保持
   geomType: GeometryType;
+  length?: number;
   area?: number;
+  perimeter?: number;
 }
 
-type InteractionMode = "draw" | "pan" | "edit";
+type InteractionMode = "draw" | "pan" | "edit" | "measure";
 
 export default function App() {
   const [dbConn, setDbConn] = useState<duckdb.AsyncDuckDBConnection | null>(null);
@@ -187,6 +177,7 @@ export default function App() {
     if (spatialLoaded) {
       const res = await dbConn.query(`
         SELECT id, color, width, geom_type, ST_AsGeoJSON(geom) AS gj,
+               CASE WHEN geom_type = 'line' THEN ST_Length(geom) END AS length,
                CASE WHEN geom_type = 'polygon' THEN ST_Area(geom) END AS area
         FROM strokes
         ORDER BY created_at ASC;
@@ -199,15 +190,19 @@ export default function App() {
         const widthRaw = toNum(obj["width"]);
         const width = Number.isFinite(widthRaw) ? widthRaw : 3;
         const geomType = toGeometryType(obj["geom_type"]);
+        const lengthRaw = toNum(obj["length"]);
         const areaRaw = toNum(obj["area"]);
         const gj = JSON.parse(toStr(obj["gj"]));
+        const ptsPx = parseGeometryFromGeoJSON(gj, geomType);
         list.push({
           id,
           color,
           width,
           geomType,
-          area: Number.isFinite(areaRaw) ? areaRaw : undefined,
-          ptsPx: parseGeometryFromGeoJSON(gj, geomType),
+          length: Number.isFinite(lengthRaw) ? lengthRaw : getPolylineLength(ptsPx),
+          area: geomType === "polygon" ? (Number.isFinite(areaRaw) ? areaRaw : getPolygonArea(ptsPx)) : undefined,
+          perimeter: geomType === "polygon" ? getPolygonPerimeter(ptsPx) : undefined,
+          ptsPx,
         });
       }
     }
@@ -227,10 +222,10 @@ export default function App() {
       const width = Number.isFinite(widthRaw) ? widthRaw : 3;
       const geomType = toGeometryType(obj["geom_type"]);
       const coordsStr = toStr(obj["coords"]);
-      let pts: [number, number][] = [];
+      let pts: Point2D[] = [];
       try {
         const a = JSON.parse(coordsStr);
-        if (Array.isArray(a)) pts = a as [number, number][];
+        if (Array.isArray(a)) pts = a as Point2D[];
       } catch {
         // Ignore parsing errors, use empty array
       }
@@ -239,7 +234,9 @@ export default function App() {
         color,
         width,
         geomType,
-        area: geomType === "polygon" ? polygonArea(pts) : undefined,
+        length: getPolylineLength(pts),
+        area: geomType === "polygon" ? getPolygonArea(pts) : undefined,
+        perimeter: geomType === "polygon" ? getPolygonPerimeter(pts) : undefined,
         ptsPx: pts,
       });
     }
@@ -313,7 +310,7 @@ export default function App() {
   };
 
   // 点を動かした後にストロークを更新
-  const updateStroke = async (strokeId: string, newPtsPx: [number, number][]) => {
+  const updateStroke = async (strokeId: string, newPtsPx: Point2D[]) => {
     if (!dbConn || newPtsPx.length < 2) return;
     if (spatialLoaded) {
       const stroke = strokes.find(({ id }) => id === strokeId);
@@ -331,7 +328,7 @@ export default function App() {
   };
 
   // ドラッグ終了時に DB に保存
-  const persistStroke = async (ptsPx: [number, number][], geomType: GeometryType) => {
+  const persistStroke = async (ptsPx: Point2D[], geomType: GeometryType) => {
     if (!dbConn || ptsPx.length < (geomType === "polygon" ? 3 : 2)) return;
 
     if (spatialLoaded) {
@@ -409,7 +406,12 @@ export default function App() {
                 {/* 画面操作 - OrbitControls behavior changes based on interaction mode */}
                 <OrbitControls makeDefault enableRotate={false} enabled={interactionMode === "pan"} />
 
-                <Scene pcdFileContents={pcdFileContents} strokes={strokes} hideStrokes={interactionMode === "edit"} />
+                <Scene
+                  pcdFileContents={pcdFileContents}
+                  strokes={strokes}
+                  hideStrokes={interactionMode === "edit"}
+                  showMeasurements={interactionMode === "measure"}
+                />
                 <StrokeEditor strokes={strokes} onUpdateStroke={updateStroke} enabled={interactionMode === "edit"} />
                 <DrawingSurface
                   onFinish={persistStroke}
@@ -475,8 +477,9 @@ export default function App() {
         ) : (
           <span style={{ color: "#b45309", marginRight: 8 }}>⚠️ メモリのみ（リロードでリセット）</span>
         )}
-        Draw モード: クリックで点を追加・Escまたはダブルクリックで確定 | Edit モード: 点をドラッグで移動 | Pan モード:
-        ドラッグで移動・ホイールでズーム | PCDファイル読み込み対応 | Undo・Clear はヘッダーから
+        Draw モード: クリックで点を追加・Escまたはダブルクリックで確定 | Measure モード: 長さ・面積・周長を表示 | Edit
+        モード: 点をドラッグで移動 | Pan モード: ドラッグで移動・ホイールでズーム | PCDファイル読み込み対応 |
+        Undo・Clear はヘッダーから
       </footer>
     </div>
   );

--- a/src/components/DrawingSurface.tsx
+++ b/src/components/DrawingSurface.tsx
@@ -70,8 +70,10 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
     if (!enabled) return;
     e.stopPropagation();
     const p = e.point;
+    const nextWorld: [number, number, number] = [p.x, p.y, 0];
     currentPtsPxRef.current = [...currentPtsPxRef.current, worldToPx(p.x, p.y)];
-    setCurrentPtsWorld((prev) => [...prev, [p.x, p.y, 0]]);
+    setCurrentPtsWorld((prev) => [...prev, nextWorld]);
+    setHoverWorld(nextWorld);
   };
 
   const onPointerMove = (e: { point: { x: number; y: number; z: number } }) => {
@@ -87,9 +89,12 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
 
   // プレビュー線：最後の確定点 → 現在のカーソル位置
   const lastPt = currentPtsWorld[currentPtsWorld.length - 1];
-  const previewLine = enabled && lastPt && hoverWorld ? [lastPt, hoverWorld] : null;
+  const hasPreviewTarget = Boolean(
+    enabled && lastPt && hoverWorld && Math.hypot(hoverWorld[0] - lastPt[0], hoverWorld[1] - lastPt[1]) > 0.001
+  );
+  const previewLine = hasPreviewTarget && lastPt && hoverWorld ? [lastPt, hoverWorld] : null;
   const previewPtsPx =
-    enabled && hoverWorld && currentPtsPxRef.current.length > 0
+    hasPreviewTarget && hoverWorld && currentPtsPxRef.current.length > 0
       ? [...currentPtsPxRef.current, worldToPx(hoverWorld[0], hoverWorld[1])]
       : [];
   const previewIsPolygon = isPolygonCloseCandidate(previewPtsPx);
@@ -114,7 +119,7 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
           opacity={0.4}
         />
       )}
-      {enabled && hoverWorld && previewPtsPx.length >= 2 && (
+      {hasPreviewTarget && hoverWorld && previewPtsPx.length >= 2 && (
         <Html position={[hoverWorld[0], hoverWorld[1], 0.002]} center>
           <div
             style={{

--- a/src/components/DrawingSurface.tsx
+++ b/src/components/DrawingSurface.tsx
@@ -1,9 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useThree } from "@react-three/fiber";
-import { Line } from "@react-three/drei";
+import { Html, Line } from "@react-three/drei";
+import {
+  getPolygonArea,
+  getPolygonPerimeter,
+  getPolylineLength,
+  isPolygonCloseCandidate,
+  type Point2D,
+} from "../lib/geometry";
 
 interface DrawingSurfaceProps {
-  onFinish: (ptsPx: [number, number][], type: "line" | "polygon") => void | Promise<void>;
+  onFinish: (ptsPx: Point2D[], type: "line" | "polygon") => void | Promise<void>;
   color: string;
   width: number;
   enabled: boolean;
@@ -13,13 +20,16 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
   const { size, viewport } = useThree();
   const [currentPtsWorld, setCurrentPtsWorld] = useState<[number, number, number][]>([]);
   const [hoverWorld, setHoverWorld] = useState<[number, number, number] | null>(null);
-  const currentPtsPxRef = useRef<[number, number][]>([]);
+  const currentPtsPxRef = useRef<Point2D[]>([]);
 
-  const worldToPx = (wx: number, wy: number): [number, number] => {
-    const x = ((wx + viewport.width / 2) / viewport.width) * size.width;
-    const y = ((viewport.height / 2 - wy) / viewport.height) * size.height;
-    return [x, y];
-  };
+  const worldToPx = useCallback(
+    (wx: number, wy: number): Point2D => {
+      const x = ((wx + viewport.width / 2) / viewport.width) * size.width;
+      const y = ((viewport.height / 2 - wy) / viewport.height) * size.height;
+      return [x, y];
+    },
+    [size.height, size.width, viewport.height, viewport.width]
+  );
 
   const planeArgs = useMemo<[number, number]>(() => [viewport.width, viewport.height], [viewport]);
 
@@ -34,7 +44,7 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
     if (ptsPx.length < 2) return;
     const [startX, startY] = ptsPx[0];
     const [endX, endY] = ptsPx[ptsPx.length - 1];
-    const type = ptsPx.length >= 3 && Math.hypot(endX - startX, endY - startY) <= 20 ? "polygon" : "line";
+    const type = ptsPx.length >= 4 && Math.hypot(endX - startX, endY - startY) <= 20 ? "polygon" : "line";
     await onFinish(type === "polygon" ? ptsPx.slice(0, -1) : ptsPx, type);
   }, [onFinish]);
 
@@ -71,6 +81,14 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
   // プレビュー線：最後の確定点 → 現在のカーソル位置
   const lastPt = currentPtsWorld[currentPtsWorld.length - 1];
   const previewLine = enabled && lastPt && hoverWorld ? [lastPt, hoverWorld] : null;
+  const previewPtsPx =
+    enabled && hoverWorld && currentPtsPxRef.current.length > 0
+      ? [...currentPtsPxRef.current, worldToPx(hoverWorld[0], hoverWorld[1])]
+      : [];
+  const previewIsPolygon = isPolygonCloseCandidate(previewPtsPx);
+  const previewPolygonPts = previewIsPolygon ? previewPtsPx.slice(0, -1) : [];
+  const previewLength = previewIsPolygon ? getPolygonPerimeter(previewPolygonPts) : getPolylineLength(previewPtsPx);
+  const previewArea = previewIsPolygon ? getPolygonArea(previewPolygonPts) : undefined;
 
   // 最後の点のハイライト用サイズ
   const dotRadius = Math.max(0.01, (width / Math.max(size.width, size.height)) * viewport.width * 0.8);
@@ -88,6 +106,31 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
           transparent
           opacity={0.4}
         />
+      )}
+      {enabled && hoverWorld && previewPtsPx.length >= 2 && (
+        <Html position={[hoverWorld[0], hoverWorld[1], 0.002]} center>
+          <div
+            style={{
+              padding: "2px 5px",
+              borderRadius: 4,
+              background: "rgba(255, 255, 255, 0.85)",
+              color: "#333",
+              fontSize: 11,
+              whiteSpace: "nowrap",
+              pointerEvents: "none",
+              textAlign: "left",
+            }}
+          >
+            {previewIsPolygon ? (
+              <>
+                <div>Area: {previewArea?.toFixed(1)} px²</div>
+                <div>Perimeter: {previewLength.toFixed(1)} px</div>
+              </>
+            ) : (
+              <div>Length: {previewLength.toFixed(1)} px</div>
+            )}
+          </div>
+        </Html>
       )}
       {/* 最後の点のハイライト */}
       {enabled && lastPt && (

--- a/src/components/DrawingSurface.tsx
+++ b/src/components/DrawingSurface.tsx
@@ -59,6 +59,13 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [enabled, finishStroke]);
 
+  useEffect(() => {
+    if (enabled) return;
+    currentPtsPxRef.current = [];
+    setCurrentPtsWorld([]);
+    setHoverWorld(null);
+  }, [enabled]);
+
   const onClick = (e: { stopPropagation: () => void; point: { x: number; y: number; z: number } }) => {
     if (!enabled) return;
     e.stopPropagation();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-type InteractionMode = "draw" | "pan" | "edit";
+type InteractionMode = "draw" | "pan" | "edit" | "measure";
 
 interface HeaderProps {
   interactionMode: InteractionMode;
@@ -112,6 +112,20 @@ export function Header({
             }}
           >
             Edit
+          </button>
+          <button
+            onClick={() => setInteractionMode("measure")}
+            style={{
+              padding: "4px 8px",
+              fontSize: 12,
+              backgroundColor: interactionMode === "measure" ? "#0f766e" : "#f8f9fa",
+              color: interactionMode === "measure" ? "white" : "#212529",
+              border: "1px solid #dee2e6",
+              borderRadius: 4,
+              cursor: "pointer",
+            }}
+          >
+            Measure
           </button>
         </div>
 

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -3,6 +3,7 @@ import { useThree } from "@react-three/fiber";
 import { Html, Line } from "@react-three/drei";
 import * as THREE from "three";
 import { PCDFromFile } from "./PCDLoader";
+import { getCentroid } from "../lib/geometry";
 
 interface Stroke {
   id: string;
@@ -10,16 +11,19 @@ interface Stroke {
   width: number;
   ptsPx: [number, number][];
   geomType: "line" | "polygon";
+  length?: number;
   area?: number;
+  perimeter?: number;
 }
 
 interface SceneProps {
   strokes: Stroke[];
   pcdFileContents: string[];
   hideStrokes?: boolean;
+  showMeasurements?: boolean;
 }
 
-export function Scene({ strokes, pcdFileContents, hideStrokes = false }: SceneProps) {
+export function Scene({ strokes, pcdFileContents, hideStrokes = false, showMeasurements = false }: SceneProps) {
   const { size, viewport } = useThree();
 
   const renderedStrokes = useMemo(() => {
@@ -33,18 +37,15 @@ export function Scene({ strokes, pcdFileContents, hideStrokes = false }: ScenePr
       const points = s.ptsPx.map(([x, y]) => pxToWorld(x, y));
       const isPolygon = s.geomType === "polygon" && points.length >= 3;
       const shape = isPolygon ? new THREE.Shape(points.map(([x, y]) => new THREE.Vector2(x, y))) : undefined;
-      const labelPosition = isPolygon
-        ? ([
-            points.reduce((sum, [x]) => sum + x, 0) / points.length,
-            points.reduce((sum, [, y]) => sum + y, 0) / points.length,
-            0.002,
-          ] as [number, number, number])
-        : undefined;
+      const centroidWorld = pxToWorld(...getCentroid(s.ptsPx));
+      const measurementPosition = isPolygon
+        ? ([centroidWorld[0], centroidWorld[1], 0.002] as [number, number, number])
+        : points[points.length - 1];
       return {
         ...s,
         points: isPolygon ? [...points, points[0]] : points,
         shape,
-        labelPosition,
+        measurementPosition,
       };
     });
   }, [strokes, size, viewport]);
@@ -61,8 +62,8 @@ export function Scene({ strokes, pcdFileContents, hideStrokes = false }: ScenePr
               </mesh>
             )}
             <Line points={s.points} color={s.color} lineWidth={s.width} />
-            {s.labelPosition && Number.isFinite(s.area) && (
-              <Html position={s.labelPosition} center>
+            {showMeasurements && s.measurementPosition && (
+              <Html position={s.measurementPosition} center>
                 <div
                   style={{
                     padding: "2px 5px",
@@ -72,9 +73,17 @@ export function Scene({ strokes, pcdFileContents, hideStrokes = false }: ScenePr
                     fontSize: 11,
                     whiteSpace: "nowrap",
                     pointerEvents: "none",
+                    textAlign: "left",
                   }}
                 >
-                  {s.area?.toFixed(1)} px²
+                  {s.geomType === "polygon" ? (
+                    <>
+                      {Number.isFinite(s.area) && <div>Area: {s.area?.toFixed(1)} px²</div>}
+                      {Number.isFinite(s.perimeter) && <div>Perimeter: {s.perimeter?.toFixed(1)} px</div>}
+                    </>
+                  ) : (
+                    Number.isFinite(s.length) && <div>Length: {s.length?.toFixed(1)} px</div>
+                  )}
                 </div>
               </Html>
             )}

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -34,15 +34,18 @@ export function Scene({ strokes, pcdFileContents, hideStrokes = false, showMeasu
     };
 
     return strokes.map((s) => {
-      const points = s.ptsPx.map(([x, y]) => pxToWorld(x, y));
+      const ptsPx = s.ptsPx.filter(([x, y]) => Number.isFinite(x) && Number.isFinite(y));
+      const points = ptsPx.map(([x, y]) => pxToWorld(x, y));
+      const isRenderable = points.length >= 2;
       const isPolygon = s.geomType === "polygon" && points.length >= 3;
       const shape = isPolygon ? new THREE.Shape(points.map(([x, y]) => new THREE.Vector2(x, y))) : undefined;
-      const centroidWorld = pxToWorld(...getCentroid(s.ptsPx));
+      const centroidWorld = pxToWorld(...getCentroid(ptsPx));
       const measurementPosition = isPolygon
         ? ([centroidWorld[0], centroidWorld[1], 0.002] as [number, number, number])
         : points[points.length - 1];
       return {
         ...s,
+        isRenderable,
         points: isPolygon ? [...points, points[0]] : points,
         shape,
         measurementPosition,
@@ -55,37 +58,41 @@ export function Scene({ strokes, pcdFileContents, hideStrokes = false, showMeasu
       {!hideStrokes &&
         renderedStrokes.map((s) => (
           <group key={s.id}>
-            {s.shape && (
-              <mesh position={[0, 0, -0.001]}>
-                <shapeGeometry args={[s.shape]} />
-                <meshBasicMaterial color={s.color} transparent opacity={0.25} side={THREE.DoubleSide} />
-              </mesh>
-            )}
-            <Line points={s.points} color={s.color} lineWidth={s.width} />
-            {showMeasurements && s.measurementPosition && (
-              <Html position={s.measurementPosition} center>
-                <div
-                  style={{
-                    padding: "2px 5px",
-                    borderRadius: 4,
-                    background: "rgba(255, 255, 255, 0.85)",
-                    color: "#333",
-                    fontSize: 11,
-                    whiteSpace: "nowrap",
-                    pointerEvents: "none",
-                    textAlign: "left",
-                  }}
-                >
-                  {s.geomType === "polygon" ? (
-                    <>
-                      {Number.isFinite(s.area) && <div>Area: {s.area?.toFixed(1)} px²</div>}
-                      {Number.isFinite(s.perimeter) && <div>Perimeter: {s.perimeter?.toFixed(1)} px</div>}
-                    </>
-                  ) : (
-                    Number.isFinite(s.length) && <div>Length: {s.length?.toFixed(1)} px</div>
-                  )}
-                </div>
-              </Html>
+            {!s.isRenderable ? null : (
+              <>
+                {s.shape && (
+                  <mesh position={[0, 0, -0.001]}>
+                    <shapeGeometry args={[s.shape]} />
+                    <meshBasicMaterial color={s.color} transparent opacity={0.25} side={THREE.DoubleSide} />
+                  </mesh>
+                )}
+                <Line points={s.points} color={s.color} lineWidth={s.width} />
+                {showMeasurements && s.measurementPosition && (
+                  <Html position={s.measurementPosition} center>
+                    <div
+                      style={{
+                        padding: "2px 5px",
+                        borderRadius: 4,
+                        background: "rgba(255, 255, 255, 0.85)",
+                        color: "#333",
+                        fontSize: 11,
+                        whiteSpace: "nowrap",
+                        pointerEvents: "none",
+                        textAlign: "left",
+                      }}
+                    >
+                      {s.geomType === "polygon" ? (
+                        <>
+                          {Number.isFinite(s.area) && <div>Area: {s.area?.toFixed(1)} px²</div>}
+                          {Number.isFinite(s.perimeter) && <div>Perimeter: {s.perimeter?.toFixed(1)} px</div>}
+                        </>
+                      ) : (
+                        Number.isFinite(s.length) && <div>Length: {s.length?.toFixed(1)} px</div>
+                      )}
+                    </div>
+                  </Html>
+                )}
+              </>
             )}
           </group>
         ))}

--- a/src/lib/geometry.ts
+++ b/src/lib/geometry.ts
@@ -1,0 +1,43 @@
+export type Point2D = [number, number];
+
+export const pointsEqual = ([ax, ay]: Point2D, [bx, by]: Point2D) => ax === bx && ay === by;
+
+export const getPolylineLength = (points: Point2D[]) => {
+  let length = 0;
+  for (let i = 1; i < points.length; i++) {
+    const [x1, y1] = points[i - 1];
+    const [x2, y2] = points[i];
+    length += Math.hypot(x2 - x1, y2 - y1);
+  }
+  return length;
+};
+
+export const getPolygonArea = (points: Point2D[]) => {
+  let area = 0;
+  for (let i = 0; i < points.length; i++) {
+    const [x1, y1] = points[i];
+    const [x2, y2] = points[(i + 1) % points.length];
+    area += x1 * y2 - x2 * y1;
+  }
+  return Math.abs(area) / 2;
+};
+
+export const getPolygonPerimeter = (points: Point2D[]) => {
+  if (points.length < 2) return 0;
+  return getPolylineLength([...points, points[0]]);
+};
+
+export const getCentroid = (points: Point2D[]): Point2D => {
+  if (points.length === 0) return [0, 0];
+  return [
+    points.reduce((sum, [x]) => sum + x, 0) / points.length,
+    points.reduce((sum, [, y]) => sum + y, 0) / points.length,
+  ];
+};
+
+export const isPolygonCloseCandidate = (points: Point2D[], thresholdPx = 20) => {
+  if (points.length < 4) return false;
+  const [startX, startY] = points[0];
+  const [endX, endY] = points[points.length - 1];
+  return Math.hypot(endX - startX, endY - startY) <= thresholdPx;
+};


### PR DESCRIPTION
## Summary
- add shared geometry utilities for px-based length, area, perimeter, centroid, and close-candidate detection
- add Measure mode for saved drawings
- show saved line length and polygon area/perimeter labels in the Three.js canvas
- show live drawing measurements while previewing a new line or polygon
- use DuckDB spatial for saved line length (`ST_Length`) and polygon area (`ST_Area`) when available, with JS fallback calculations for non-spatial paths and perimeter

## Scope
This PR focuses on per-geometry basic measurement and live drawing feedback. It intentionally keeps the app direction centered on drawing and geometry operations rather than map/GIS workflows.

## Deferred To Separate Issues / PRs
- Two-geometry distance measurement (`ST_Distance`) should be a separate PR because it needs a distinct selection flow for choosing two shapes.
- Shape-to-shape predicates such as contains/intersects should be handled separately, likely alongside selection/filter work such as #20.
- Real-world unit conversion should be separate from this px-based geometry pass, because it needs scale configuration and UI decisions.
- Advanced measurement editing, persistent measurement annotations, or side-panel geometry inspection should be separate UI-focused follow-ups.

## Validation
- `npm run build`
- `npm run lint`

Closes #21