### PR TITLE
[codex] Add agent testing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# Agent Guide
+
+## Project Overview
+
+This is a Vite + React + TypeScript app for drawing and measuring 2D geometry on a React Three Fiber canvas. It stores drawn strokes in DuckDB WASM, uses the DuckDB spatial extension when available, can display point clouds from PCD files, and can switch to a MapLibre map view.
+
+Core files:
+
+- `src/App.tsx`: application state, DuckDB setup, persistence, mode wiring.
+- `src/components/DrawingSurface.tsx`: click-based line and polygon drawing on the R3F canvas.
+- `src/components/Scene.tsx`: renders saved strokes, filled polygons, measurements, and PCD content.
+- `src/components/StrokeEditor.tsx`: edit mode for dragging existing stroke points.
+- `src/components/Header.tsx`: toolbar controls.
+- `src/lib/geometry.ts`: pure geometry helpers for length, area, perimeter, centroid, and polygon closing.
+
+## Development Commands
+
+- Install dependencies: `npm install`
+- Start dev server: `npm run dev`
+- Build: `npm run build`
+- Lint: `npm run lint`
+- Format: `npm run format`
+- Check formatting: `npm run format:check`
+- Preview production build: `npm run preview`
+
+The Vite dev server sets `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers because DuckDB WASM can require cross-origin isolation.
+
+## Coding Notes
+
+- Keep coordinate storage in pixel coordinates (`Point2D`) unless changing the persistence model intentionally.
+- Preserve the fallback JSON table path for environments where the DuckDB spatial extension cannot load.
+- Prefer extending `src/lib/geometry.ts` for pure geometry behavior and test those helpers directly when a test runner is added.
+- Avoid unrelated UI refactors when changing drawing, measurement, persistence, or map behavior.
+- When changing canvas interactions, verify draw, edit, measure, pan, undo, clear, refresh, and PCD loading paths as applicable.
+
+## Testing Guidance
+
+There is currently no committed automated test runner. For now, run at minimum:
+
+```sh
+npm run lint
+npm run build
+```
+
+Recommended future test layers:
+
+1. Unit tests for `src/lib/geometry.ts`.
+2. Integration tests for WKT/GeoJSON conversion and persistence behavior.
+3. Playwright end-to-end tests for toolbar modes and canvas drawing behavior.
+
+For canvas drawing tests, Playwright can exercise deterministic pointer coordinates. Use the canvas bounding box as the coordinate origin, then click or drag relative to it. For this app, drawing is click-based: click points, then double-click or press Escape to finish.
+
+Example Playwright flow:
+
+```ts
+const canvas = page.locator("canvas");
+await expect(canvas).toBeVisible();
+
+const box = await canvas.boundingBox();
+if (!box) throw new Error("canvas not found");
+
+await page.mouse.click(box.x + 100, box.y + 100);
+await page.mouse.click(box.x + 240, box.y + 100);
+await page.mouse.click(box.x + 240, box.y + 180);
+await page.keyboard.press("Escape");
+```
+
+Validation options:
+
+- Prefer element screenshots for WebGL/R3F output: `await expect(canvas).toHaveScreenshot("line.png")`.
+- Use deterministic viewport sizes to reduce snapshot churn.
+- Validate measurement labels in DOM when measure mode is active.
+- For WebGL canvas, do not assume `getContext("2d").getImageData()` is available. Screenshot comparison is usually the practical path.
+- If canvas output is flaky, add stable test IDs or DOM-accessible state summaries rather than relying only on pixel snapshots.
+
+Before finishing a change that affects rendering, use Playwright screenshots when possible to confirm that the canvas is nonblank and that expected geometry appears in desktop and mobile viewport sizes.

--- a/README.md
+++ b/README.md
@@ -1,69 +1,116 @@
-# React + TypeScript + Vite
+# Vite React Three Drawing App
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A browser-based drawing and measurement prototype built with Vite, React, TypeScript, React Three Fiber, DuckDB WASM, and MapLibre.
 
-Currently, two official plugins are available:
+The app lets you draw lines and polygons on a 2D Three.js canvas, persist them in DuckDB, measure length/area/perimeter, edit saved points, load PCD point-cloud files, and switch to a Tokyo-centered map view.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Features
 
-## Expanding the ESLint configuration
+- Draw mode: click points on the canvas, then press Escape or double-click to save.
+- Polygon detection: close a shape by ending near the first point.
+- Measure mode: displays line length or polygon area/perimeter.
+- Edit mode: move saved stroke points.
+- Pan mode: pan and zoom the orthographic canvas.
+- DuckDB WASM persistence with OPFS when available.
+- DuckDB spatial extension support with JSON-table fallback.
+- PCD file loading and rendering.
+- MapLibre map view using OpenStreetMap Japan styling.
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+## Requirements
 
-```js
-export default tseslint.config([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
+- Node.js 22 or newer is recommended.
+- npm
 
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
+## Getting Started
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
+Install dependencies:
+
+```sh
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Start the development server:
 
-```js
-// eslint.config.js
-import reactX from "eslint-plugin-react-x";
-import reactDom from "eslint-plugin-react-dom";
-
-export default tseslint.config([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs["recommended-typescript"],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
+```sh
+npm run dev
 ```
+
+Build for production:
+
+```sh
+npm run build
+```
+
+Preview a production build:
+
+```sh
+npm run preview
+```
+
+## Scripts
+
+- `npm run dev`: start Vite.
+- `npm run build`: run TypeScript build checks and create a Vite production build.
+- `npm run lint`: run ESLint.
+- `npm run lint:fix`: run ESLint with automatic fixes.
+- `npm run format`: format files with Prettier.
+- `npm run format:check`: check Prettier formatting.
+- `npm run preview`: preview the production build.
+
+## App Structure
+
+- `src/App.tsx`: app state, DuckDB initialization, persistence, and mode switching.
+- `src/components/Header.tsx`: toolbar controls.
+- `src/components/DrawingSurface.tsx`: canvas drawing interactions.
+- `src/components/Scene.tsx`: stroke, measurement, polygon, and PCD rendering.
+- `src/components/StrokeEditor.tsx`: point editing.
+- `src/components/MapView.tsx`: MapLibre map display.
+- `src/lib/geometry.ts`: geometry calculations.
+- `src/dbBundles.ts`: manually bundled DuckDB WASM assets.
+
+## DuckDB Notes
+
+The app attempts to open an OPFS-backed DuckDB database at `opfs://vite-react-three.duckdb`. If OPFS is unavailable, it falls back to an in-memory database.
+
+The app also attempts to install and load DuckDB's `spatial` extension. When the extension is unavailable, geometry is still stored in the JSON fallback table, but spatial-specific behavior may be limited.
+
+The Vite dev server sends cross-origin isolation headers required by some DuckDB WASM configurations:
+
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Embedder-Policy: require-corp`
+
+## Testing
+
+There is no committed automated test runner yet. For current validation, run:
+
+```sh
+npm run lint
+npm run build
+```
+
+Good next steps for automated coverage:
+
+- Add unit tests for `src/lib/geometry.ts`.
+- Add tests for geometry serialization and persistence behavior.
+- Add Playwright tests for draw, edit, measure, pan, undo, clear, and PCD-loading workflows.
+
+Playwright can test canvas drawing by using fixed pointer coordinates relative to the canvas bounding box. This app's drawing flow is click-based:
+
+```ts
+const canvas = page.locator("canvas");
+const box = await canvas.boundingBox();
+if (!box) throw new Error("canvas not found");
+
+await page.mouse.click(box.x + 100, box.y + 100);
+await page.mouse.click(box.x + 240, box.y + 100);
+await page.mouse.click(box.x + 240, box.y + 180);
+await page.keyboard.press("Escape");
+```
+
+For React Three Fiber/WebGL output, prefer canvas screenshots with a fixed viewport:
+
+```ts
+await expect(canvas).toHaveScreenshot("drawn-line.png");
+```
+
+Pixel reads through `getContext("2d")` are not reliable for WebGL canvas output, so screenshot comparisons or DOM-visible measurement labels are usually better assertions.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with project structure, development commands, coding notes, and testing guidance for AI agents.
- Replace the default Vite README with project-specific setup, feature, DuckDB, and testing documentation.
- Document Playwright-based canvas drawing test guidance for deterministic pointer-coordinate workflows.

## Validation

- `npm run lint`
- `npm run build`

Note: `npm run format:check` currently fails on pre-existing formatting issues in `package.json` and `public/coi-serviceworker.js`, which were not changed in this PR.