### PR TITLE
Phase 0のブラウザ操作カバレッジを完成

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,231 @@
+# Roadmap
+
+## Product Direction
+
+This project is a browser-based geometry workbench that uses DuckDB and the
+DuckDB spatial extension as its computation and query engine.
+
+It does not aim to compete with tldraw or Excalidraw as a general-purpose
+whiteboard. Drawing is the input method; the differentiator is being able to
+store, inspect, transform, query, and export geometry with SQL in the browser.
+
+## Guiding Principles
+
+- Make DuckDB operations visible and understandable instead of hiding them
+  behind drawing-only interactions.
+- Treat every geometry as data with an ID, geometry type, attributes, and layer
+  membership.
+- Keep browser-local operation as the default. A backend should not be required
+  for the core workflow.
+- Add visual tools when they expose a useful spatial operation, not only because
+  they are common in whiteboard software.
+- Reintroduce map and point-cloud views only when they share the same layer,
+  selection, query, and export model as other geometry.
+
+## Phase 0: Stabilize the Geometry Core
+
+Goal: establish a reliable base before expanding the product surface.
+
+- [x] Define a canonical feature model for IDs, geometry, properties, style, and
+      layer membership.
+- [x] Separate geometry persistence and queries from React component state.
+- [x] Make spatial-extension availability and JSON fallback behavior explicit
+      in the UI.
+- [x] Add unit tests for geometry calculations and integration tests for
+      GeoJSON conversion and persistence.
+- [x] Extend Playwright coverage for draw, edit, measure, pan, undo, clear,
+      refresh, and GeoJSON import/export.
+
+Exit criteria:
+
+- Existing workflows survive reloads consistently.
+- The same feature can round-trip through DuckDB and GeoJSON without losing its
+  geometry type or properties.
+- Core geometry and persistence tests run in CI.
+
+## Phase 1: DuckDB Spatial Lab
+
+Goal: make DuckDB the visible center of the application.
+
+- Add a SQL editor with query execution, history, cancellation, and clear error
+  messages.
+- Expose documented read-only views for features and layers.
+- Show tabular query results alongside the canvas.
+- Render geometry returned by a query as a temporary result layer.
+- Allow a result layer to be saved as a persistent layer.
+- Include runnable examples for filtering, measuring, constructing, and
+  converting geometry.
+
+Exit criteria:
+
+- A user can draw geometry, query it with SQL, see both rows and geometry
+  results, and save or export the result without leaving the browser.
+
+## Phase 2: Layers, Attributes, and Selection
+
+Goal: turn independent strokes into a workable spatial dataset.
+
+- Add a layer panel with visibility, ordering, rename, delete, and active-layer
+  controls.
+- Add feature selection from both the canvas and result table.
+- Add an attribute table with sorting, filtering, and property editing.
+- Synchronize selection between canvas, SQL results, and attribute table.
+- Add per-layer style controls based on geometry type and attributes.
+- Provide GeoJSON import mapping and per-layer export.
+
+Exit criteria:
+
+- Multiple datasets can be inspected and compared without losing track of their
+  source, attributes, or selection state.
+
+## Phase 3: Spatial Operations
+
+Goal: provide practical geometry processing backed by DuckDB Spatial.
+
+- Add buffer, simplify, centroid, envelope, intersection, union, difference,
+  and spatial predicate tools.
+- Generate tool forms from a small operation schema so SQL and UI tools share
+  one implementation path.
+- Show input layers, parameters, generated SQL, preview, and output destination
+  for every operation.
+- Keep operations non-destructive by default and write results to a new layer.
+- Record operation provenance so a result can be reproduced.
+
+Exit criteria:
+
+- Common spatial transformations can be performed from either SQL or the UI,
+  produce equivalent results, and remain reproducible.
+
+## Phase 4: Coordinates and Map Context
+
+Goal: support real-world spatial data after the layer model is established.
+
+- Add coordinate reference system metadata and explicit pixel/world coordinate
+  handling.
+- Define import behavior for datasets with missing or unsupported CRS metadata.
+- Add coordinate readout, scale-aware measurements, and viewport bounds.
+- Reintroduce a map as a layer-backed basemap or geographic viewport, not as a
+  separate application mode.
+- Verify reprojection support available in DuckDB Spatial before exposing CRS
+  conversion in the UI.
+
+Exit criteria:
+
+- Geographic data can be imported, measured, queried, displayed over a map, and
+  exported without silently changing coordinates.
+
+## Phase 5: Data Formats and Larger Datasets
+
+Goal: demonstrate DuckDB's value beyond hand-drawn geometry.
+
+- Add import and export support based on formats DuckDB Spatial can reliably
+  handle in the browser.
+- Add CSV ingestion with configurable longitude/latitude or WKT columns.
+- Explore GeoParquet and FlatGeobuf for larger vector datasets.
+- Add query-driven loading, bounding-box filtering, and geometry
+  simplification for responsive rendering.
+- Re-evaluate PCD support only after point clouds can participate in the common
+  layer, metadata, visibility, and query model.
+
+Exit criteria:
+
+- A dataset larger than the interactive drawing use case can be loaded,
+  filtered through DuckDB, and rendered without requiring all source geometry
+  in React state.
+
+## Later Opportunities
+
+These are intentionally deferred until the spatial workbench is coherent:
+
+- Shareable project files and deterministic session export.
+- Reusable SQL notebooks or analysis recipes.
+- Spatial joins and multi-step operation pipelines.
+- Plugin APIs for custom importers, renderers, and operations.
+- Collaboration features based on explicit demand.
+
+General whiteboard features such as freehand illustration, rich text layout,
+stickers, presentation mode, and real-time multiplayer are not priorities unless
+they directly support a spatial-analysis workflow.
+
+## Near-Term Milestones
+
+1. [x] Complete the canonical feature and layer schema.
+2. [x] Add automated tests around geometry persistence and GeoJSON round-trips.
+3. [x] Complete Phase 0 browser workflow coverage.
+4. [ ] Build the SQL editor and tabular result view.
+5. [ ] Render query geometry as a temporary layer.
+6. [ ] Promote query results to persistent layers.
+7. [ ] Build the layer panel and synchronized selection.
+
+The first major product milestone is complete when a user can draw or import
+geometry, query it with DuckDB SQL, inspect the resulting rows and shapes, and
+save or export the result entirely in the browser.
+
+## Current Status
+
+### Completed on 2026-07-18
+
+- Added the canonical feature and layer model, including IDs, properties, style,
+  layer membership, and deterministic insertion order.
+- Moved DuckDB initialization, persistence, migration, and GeoJSON conversion
+  out of React component state.
+- Added sticky Spatial/JSON store selection and made OPFS, memory, Spatial, and
+  JSON fallback status visible in the UI.
+- Added Vitest coverage for geometry, the canonical model, GeoJSON, persistence,
+  migration, operation ordering, and import/export.
+- Added browser coverage for drawing, measurement, refresh/reload durability,
+  undo, and GeoJSON round-trips.
+
+The canonical persistence implementation was merged in PR #36. Phase 0 browser
+workflow coverage was completed on 2026-07-19, including a fix that maps primary
+pointer dragging to Pan instead of the disabled Rotate action.
+
+## Today: 2026-07-19
+
+Goal: finish the Phase 0 verification boundary, then prepare the first Phase 1
+slice without mixing both concerns into one implementation change.
+
+### Must do
+
+- [x] Write a browser-workflow coverage matrix for draw, edit, measure, pan,
+      undo, clear, refresh/reload, and GeoJSON import/export.
+- [x] Add the missing high-value Playwright paths, especially edit persistence,
+      pan interaction, and explicit clear persistence.
+- [x] Keep stateful E2E deterministic: use serial execution, test-owned data,
+      observable cleanup, and assertions tied to the geometry created by each
+      test.
+- [x] Run unit tests, Playwright, lint, and build; record any known environmental
+      warnings separately from product failures.
+
+Browser workflow coverage:
+
+| Workflow              | Observable verification                                             |
+| --------------------- | ------------------------------------------------------------------- |
+| Draw and measure      | Draw a known line and assert its exact measurement                  |
+| Edit                  | Drag a known endpoint and assert the changed exact measurement      |
+| Pan                   | Assert the measurement label moves and feature count stays stable   |
+| Undo                  | Assert the most recently inserted feature is removed                |
+| Clear                 | Assert geometry stays absent after refresh and reload               |
+| Refresh and reload    | Assert exact geometry survives both operations                      |
+| GeoJSON import/export | Assert geometry type, properties, style, layer, and ID semantics    |
+| Desktop and mobile    | Run the complete workflow suite in both deterministic viewport sets |
+
+Verification completed on 2026-07-19:
+
+- Vitest: 89 tests passed.
+- Playwright: 20 tests passed across desktop and mobile.
+- ESLint: passed.
+- Production build: passed with the existing large-chunk warning.
+
+### Next if the Phase 0 checks are green
+
+- [ ] Draft the SQL editor and tabular result-view design.
+- [ ] Put system invariants before the task list, including read-only query
+      boundaries, result-size limits, cancellation behavior, and the rule that
+      query results do not mutate persistent features implicitly.
+- [ ] Add a failure matrix covering invalid SQL, long-running and cancelled
+      queries, empty and large results, geometry/non-geometry columns,
+      Spatial/JSON stores, and component unmount or database restart.
+- [ ] Define the smallest vertical slice: execute read-only SQL against
+      documented feature/layer views and display tabular results. Temporary
+      geometry rendering remains the following milestone.

--- a/docs/superpowers/plans/2026-07-19-pan-coordinate-preservation.md
+++ b/docs/superpowers/plans/2026-07-19-pan-coordinate-preservation.md
@@ -1,0 +1,183 @@
+# Pan Coordinate Preservation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve the panned viewport across reloads while keeping drawing and editing available over the visible canvas.
+
+**Architecture:** Keep persisted `Point2D` values in model space. Store camera position and OrbitControls target as browser-local viewport state, restore both together, and move only the transparent interaction planes with the camera.
+
+**Tech Stack:** React 19, React Three Fiber, Three.js orthographic camera, Vitest, Playwright
+
+## Global Constraints
+
+- Keep persisted coordinates as `Point2D` pixel coordinates.
+- Do not change the persistence schema.
+- Do not configure touch gestures.
+- Preserve draw, edit, measure, pan, refresh, reload, and GeoJSON behavior.
+
+---
+
+### Task 1: Reproduce viewport loss after reload
+
+**Files:**
+
+- Modify: `tests/e2e/app.spec.ts`
+
+**Interfaces:**
+
+- Consumes: the existing toolbar, canvas pointer interactions, GeoJSON export, and reload workflow.
+- Produces: a regression test that proves a panned viewport and its rendered geometry survive reload.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add a focused Playwright test that clears storage, draws a known line, pans the
+camera, records the measurement bounding box, reloads, enables Measure again,
+and asserts the measurement bounding box remains within two pixels of the
+pre-reload location.
+
+- [ ] **Step 2: Run the focused test**
+
+Run:
+
+```sh
+npx playwright test tests/e2e/app.spec.ts --grep "Pan後の座標"
+```
+
+Expected: FAIL because reload resets the camera and the measurement returns to
+its un-panned location.
+
+- [ ] **Step 3: Inspect the R3F values at the failure boundary**
+
+The failure distance must match the Pan displacement while exported geometry
+coordinates remain unchanged, proving viewport loss rather than coordinate
+corruption.
+
+### Task 2: Persist and restore viewport state
+
+**Files:**
+
+- Create: `src/lib/viewportState.ts`
+- Create: `src/lib/viewportState.test.ts`
+- Create: `src/components/PanControls.tsx`
+- Modify: `src/App.tsx`
+
+**Interfaces:**
+
+- Produces: validated load/save functions for camera position and controls
+  target, plus a Pan controls component that applies them.
+- Consumes: browser `localStorage`, R3F camera, and Drei `OrbitControls`.
+
+- [ ] **Step 1: Write failing unit tests**
+
+Cover missing, malformed, non-finite, and valid viewport-state JSON. Valid state
+contains finite `cameraX`, `cameraY`, `targetX`, and `targetY` numbers.
+
+- [ ] **Step 2: Verify the unit tests fail**
+
+Run:
+
+```sh
+npm test -- src/lib/viewportState.test.ts
+```
+
+Expected: FAIL because the viewport-state module does not exist.
+
+- [ ] **Step 3: Implement the smallest pure helper**
+
+Implement validated browser-local load/save helpers with a stable storage key.
+Storage failures must fall back silently because viewport persistence is not
+allowed to block geometry work.
+
+- [ ] **Step 4: Integrate the helper**
+
+Create `PanControls` to restore camera and target together and save them from
+the controls change callback. Replace the inline `OrbitControls` in `App.tsx`.
+
+- [ ] **Step 5: Verify unit and focused browser tests**
+
+Run:
+
+```sh
+npm test -- src/lib/viewportState.test.ts
+npx playwright test tests/e2e/app.spec.ts --grep "Pan後の座標"
+```
+
+Expected: PASS.
+
+### Task 3: Keep interaction planes in the visible viewport
+
+**Files:**
+
+- Modify: `src/components/DrawingSurface.tsx`
+- Modify: `src/components/StrokeEditor.tsx`
+- Modify: `tests/e2e/app.spec.ts`
+
+**Interfaces:**
+
+- Consumes: current R3F camera x/y position.
+- Produces: camera-centered transparent planes without changing model-space geometry.
+
+- [ ] **Step 1: Extend the failing browser regression**
+
+After Pan, switch to Draw and create a line near the visible canvas edges.
+Then switch to Edit and drag an endpoint. Assert both operations persist and
+remain visible after reload.
+
+- [ ] **Step 2: Verify the extended regression fails**
+
+Run the focused Playwright test and confirm the large Pan leaves at least one
+pointer location outside the existing origin-centered plane.
+
+- [ ] **Step 3: Center interaction planes on the camera**
+
+Read `camera` from `useThree()` and set each transparent plane position to
+`[camera.position.x, camera.position.y, z]`. Do not offset rendered strokes,
+handles, previews, or persisted coordinates.
+
+- [ ] **Step 4: Verify the focused regression passes**
+
+Run the focused Playwright test for desktop and mobile and expect both to pass.
+
+### Task 4: Regression verification
+
+**Files:**
+
+- Modify only files needed to correct formatting or type errors introduced above.
+
+**Interfaces:**
+
+- Consumes: completed regression and implementation.
+- Produces: repository-wide verification evidence.
+
+- [ ] **Step 1: Run the full unit suite**
+
+```sh
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run the full browser suite**
+
+```sh
+npm run test:e2e
+```
+
+Expected: all desktop and mobile projects pass.
+
+- [ ] **Step 3: Run static checks**
+
+```sh
+npm run lint
+npm run build
+npm run format:check
+git diff --check
+```
+
+Expected: all commands pass; existing Vite chunk-size and DuckDB sourcemap
+warnings may remain.
+
+- [ ] **Step 4: Review scope**
+
+Confirm the diff does not configure `touches.ONE`, alter persistence, or include
+unrelated UI refactors.

--- a/docs/superpowers/plans/2026-07-19-pan-coordinate-preservation.md
+++ b/docs/superpowers/plans/2026-07-19-pan-coordinate-preservation.md
@@ -87,6 +87,45 @@ npx playwright test tests/e2e/app.spec.ts --grep "PanとZoom"
 
 Expected: PASS on desktop and mobile.
 
+### Task 0.1: Scale pointer coordinates by zoom
+
+**Files:**
+
+- Modify: `src/lib/canvasCoordinates.test.ts`
+- Modify: `src/lib/canvasCoordinates.ts`
+- Modify: `src/components/DrawingSurface.tsx`
+- Modify: `tests/e2e/app.spec.ts`
+
+**Interfaces:**
+
+- Extends `pointerToModelPixel` with `zoom: number`.
+- Converts NDC offset around the canvas center using `offset / zoom`.
+
+- [ ] **Step 1: Write failing unit tests**
+
+Cover zoom `0.5`, `1`, and `2` with a non-central pointer and assert the model
+pixel offset expands, stays unchanged, or contracts respectively.
+
+- [ ] **Step 2: Verify zoom tests fail**
+
+Run `npm test -- src/lib/canvasCoordinates.test.ts` and expect the non-default
+zoom cases to fail with the old unscaled coordinates.
+
+- [ ] **Step 3: Implement the centered zoom transform**
+
+Calculate canvas center, divide the NDC-derived pointer offset by zoom, then add
+the camera Pan offset. Pass `camera.zoom` from `DrawingSurface`.
+
+- [ ] **Step 4: Correct the browser expectation**
+
+Calculate expected model length as screen distance divided by the saved zoom.
+Assert both the in-progress preview and persisted measurement use that value.
+
+- [ ] **Step 5: Verify focused tests**
+
+Run the coordinate unit test and the Pan/Zoom Playwright test for desktop and
+mobile; expect all to pass.
+
 ### Task 1: Reproduce viewport loss after reload
 
 **Files:**

--- a/docs/superpowers/plans/2026-07-19-pan-coordinate-preservation.md
+++ b/docs/superpowers/plans/2026-07-19-pan-coordinate-preservation.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Preserve the panned viewport across reloads while keeping drawing and editing available over the visible canvas.
+**Goal:** Preserve Pan and zoom across reloads while keeping drawing available immediately after viewport restoration.
 
-**Architecture:** Keep persisted `Point2D` values in model space. Store camera position and OrbitControls target as browser-local viewport state, restore both together, and move only the transparent interaction planes with the camera.
+**Architecture:** Keep persisted `Point2D` values in model space. Store camera position, OrbitControls target, and orthographic zoom as browser-local viewport state; restore them together, and synchronize the transparent draw plane from the render loop rather than React render timing.
 
 **Tech Stack:** React 19, React Three Fiber, Three.js orthographic camera, Vitest, Playwright
 
@@ -16,6 +16,76 @@
 - Preserve draw, edit, measure, pan, refresh, reload, and GeoJSON behavior.
 
 ---
+
+### Task 0: Address viewport restoration review feedback
+
+**Files:**
+
+- Modify: `src/lib/viewportState.test.ts`
+- Modify: `src/lib/viewportState.ts`
+- Modify: `src/components/PanControls.tsx`
+- Modify: `src/components/DrawingSurface.tsx`
+- Modify: `tests/e2e/app.spec.ts`
+
+**Interfaces:**
+
+- Extends `ViewportState` with `zoom: number`.
+- Treats stored state without `zoom` as zoom `1`.
+- Keeps the draw plane position synchronized with camera x/y on every frame.
+
+- [ ] **Step 1: Write failing zoom state tests**
+
+Add tests for valid positive zoom, legacy state without zoom, zero zoom, negative
+zoom, non-finite zoom, and saving zoom.
+
+- [ ] **Step 2: Verify the zoom tests fail**
+
+Run:
+
+```sh
+npm test -- src/lib/viewportState.test.ts
+```
+
+Expected: FAIL because viewport state does not yet load or save zoom.
+
+- [ ] **Step 3: Extend viewport state and PanControls**
+
+Load legacy state with zoom `1`, reject explicitly invalid zoom, persist current
+camera zoom, and restore zoom before calling `camera.updateProjectionMatrix()`
+and `controls.update()`.
+
+- [ ] **Step 4: Write a failing restored-Draw E2E**
+
+After Pan and zoom, reload while Draw remains the default mode. Without changing
+mode, draw a uniquely measurable line in the visible region and assert it is
+persisted. Also verify the pre-existing measurement has the same bounding box
+before and after reload.
+
+- [ ] **Step 5: Verify the restored-Draw E2E fails**
+
+Run:
+
+```sh
+npx playwright test tests/e2e/app.spec.ts --grep "PanとZoom"
+```
+
+Expected: FAIL before the draw plane frame synchronization and zoom restoration.
+
+- [ ] **Step 6: Synchronize the draw plane**
+
+Use a mesh ref and `useFrame` to copy camera x/y into the plane position. Keep
+geometry, previews, and persisted model coordinates unchanged.
+
+- [ ] **Step 7: Verify focused tests**
+
+Run:
+
+```sh
+npm test -- src/lib/viewportState.test.ts
+npx playwright test tests/e2e/app.spec.ts --grep "PanとZoom"
+```
+
+Expected: PASS on desktop and mobile.
 
 ### Task 1: Reproduce viewport loss after reload
 

--- a/docs/superpowers/specs/2026-07-19-pan-coordinate-preservation-design.md
+++ b/docs/superpowers/specs/2026-07-19-pan-coordinate-preservation-design.md
@@ -1,0 +1,42 @@
+# Pan Coordinate Preservation Design
+
+## Goal
+
+Keep persisted `Point2D` values in model-space pixel coordinates and preserve
+the panned viewport across reloads. Drawing and editing must remain available
+over the visible canvas after the orthographic camera has been panned.
+
+## Scope
+
+- Persist and restore the orthographic camera position and controls target.
+- Keep drawing and editing interaction planes aligned with the visible viewport.
+- Add browser coverage for drawing and editing after Pan followed by reload.
+- Do not change the persistence schema or configure touch gestures.
+
+## Design
+
+Treat persisted pixel coordinates as model coordinates. R3F pointer
+intersections already produce world coordinates, so the existing pixel/world
+conversion must not subtract the camera position.
+
+Add a focused Pan controls component that restores camera position and controls
+target from browser-local viewport state, then writes both values whenever the
+controls change. Camera position and target move together, preserving the
+orthographic viewing direction. Invalid or missing saved state falls back to
+the current `[0, 0, 100]` camera and `[0, 0, 0]` target.
+
+`DrawingSurface` and `StrokeEditor` will center their transparent interaction
+planes on the current camera x/y position. Geometry and edit handles remain in
+model space; only the event-capturing planes follow the visible viewport.
+
+## Verification
+
+Use test-driven development:
+
+1. Add a Playwright regression that pans, draws, reloads, and verifies the
+   measurement remains at the same rendered location.
+2. Confirm the regression fails before adding the implementation.
+3. Add viewport-state parsing tests and the smallest Pan controls integration.
+4. Add browser coverage that the visible interaction plane still accepts
+   drawing and editing after Pan.
+5. Run unit tests, the focused browser tests, lint, and build.

--- a/docs/superpowers/specs/2026-07-19-pan-coordinate-preservation-design.md
+++ b/docs/superpowers/specs/2026-07-19-pan-coordinate-preservation-design.md
@@ -20,6 +20,11 @@ Treat persisted pixel coordinates as model coordinates. R3F pointer
 intersections already produce world coordinates, so the existing pixel/world
 conversion must not subtract the camera position.
 
+Pointer NDC converts to model pixels around the canvas center. The pointer
+offset from that center is divided by the orthographic camera zoom before the
+camera Pan offset is applied. This keeps previews and persisted geometry under
+the cursor at zoom levels below, equal to, or above `1`.
+
 Add a focused Pan controls component that restores camera position, controls
 target, and zoom from browser-local viewport state, then writes those values
 whenever the controls change. Camera position and target move together,
@@ -44,4 +49,6 @@ Use test-driven development:
 4. Add browser coverage that the visible interaction plane still accepts
    drawing immediately after viewport restoration without a mode change.
 5. Add browser coverage that Pan and zoom both survive reload.
-6. Run unit tests, the focused browser tests, lint, and build.
+6. Add unit coverage for pointer conversion at zoom `0.5`, `1`, and `2`, and
+   derive the browser-test measurement from screen distance divided by zoom.
+7. Run unit tests, the focused browser tests, lint, and build.

--- a/docs/superpowers/specs/2026-07-19-pan-coordinate-preservation-design.md
+++ b/docs/superpowers/specs/2026-07-19-pan-coordinate-preservation-design.md
@@ -9,6 +9,7 @@ over the visible canvas after the orthographic camera has been panned.
 ## Scope
 
 - Persist and restore the orthographic camera position and controls target.
+- Persist and restore the orthographic camera zoom.
 - Keep drawing and editing interaction planes aligned with the visible viewport.
 - Add browser coverage for drawing and editing after Pan followed by reload.
 - Do not change the persistence schema or configure touch gestures.
@@ -19,15 +20,18 @@ Treat persisted pixel coordinates as model coordinates. R3F pointer
 intersections already produce world coordinates, so the existing pixel/world
 conversion must not subtract the camera position.
 
-Add a focused Pan controls component that restores camera position and controls
-target from browser-local viewport state, then writes both values whenever the
-controls change. Camera position and target move together, preserving the
-orthographic viewing direction. Invalid or missing saved state falls back to
-the current `[0, 0, 100]` camera and `[0, 0, 0]` target.
+Add a focused Pan controls component that restores camera position, controls
+target, and zoom from browser-local viewport state, then writes those values
+whenever the controls change. Camera position and target move together,
+preserving the orthographic viewing direction. Restoring zoom updates the
+camera projection matrix. Invalid or missing saved state falls back to the
+current `[0, 0, 100]` camera, `[0, 0, 0]` target, and zoom `1`. Saved state from
+the earlier format without zoom remains valid and receives zoom `1`.
 
-`DrawingSurface` and `StrokeEditor` will center their transparent interaction
-planes on the current camera x/y position. Geometry and edit handles remain in
-model space; only the event-capturing planes follow the visible viewport.
+`DrawingSurface` will update its transparent interaction plane from `useFrame`
+so camera restoration and control mutation do not depend on React rendering.
+Geometry and previews remain in model space; only the event-capturing plane
+follows the visible viewport.
 
 ## Verification
 
@@ -38,5 +42,6 @@ Use test-driven development:
 2. Confirm the regression fails before adding the implementation.
 3. Add viewport-state parsing tests and the smallest Pan controls integration.
 4. Add browser coverage that the visible interaction plane still accepts
-   drawing and editing after Pan.
-5. Run unit tests, the focused browser tests, lint, and build.
+   drawing immediately after viewport restoration without a mode change.
+5. Add browser coverage that Pan and zoom both survive reload.
+6. Run unit tests, the focused browser tests, lint, and build.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
+import * as THREE from "three";
 import { Header } from "./components/Header";
 import { Scene } from "./components/Scene";
 import { DrawingSurface } from "./components/DrawingSurface";
@@ -46,7 +47,12 @@ function Workspace({
           >
             <color attach="background" args={["#ffffff"]} />
             <ambientLight intensity={0.5} />
-            <OrbitControls makeDefault enableRotate={false} enabled={interactionMode === "pan"} />
+            <OrbitControls
+              makeDefault
+              enableRotate={false}
+              enabled={interactionMode === "pan"}
+              mouseButtons={{ LEFT: THREE.MOUSE.PAN, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN }}
+            />
 
             <Scene
               strokes={strokes}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
-import { OrbitControls } from "@react-three/drei";
-import * as THREE from "three";
 import { Header } from "./components/Header";
 import { Scene } from "./components/Scene";
 import { DrawingSurface } from "./components/DrawingSurface";
 import { StrokeEditor } from "./components/StrokeEditor";
+import { PanControls } from "./components/PanControls";
 import type { RenderableStroke } from "./domain/renderableStroke";
 import { useGeometryFeatures, type StorageStatus } from "./hooks/useGeometryFeatures";
 import type { Point2D } from "./domain/geometryFeature";
@@ -47,12 +46,7 @@ function Workspace({
           >
             <color attach="background" args={["#ffffff"]} />
             <ambientLight intensity={0.5} />
-            <OrbitControls
-              makeDefault
-              enableRotate={false}
-              enabled={interactionMode === "pan"}
-              mouseButtons={{ LEFT: THREE.MOUSE.PAN, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN }}
-            />
+            <PanControls enabled={interactionMode === "pan"} />
 
             <Scene
               strokes={strokes}

--- a/src/components/DrawingSurface.tsx
+++ b/src/components/DrawingSurface.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useThree } from "@react-three/fiber";
+import { useFrame, useThree } from "@react-three/fiber";
 import { Html, Line } from "@react-three/drei";
+import type { Mesh } from "three";
 import {
   getPolygonArea,
   getPolygonPerimeter,
@@ -22,6 +23,7 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
   const [currentPtsWorld, setCurrentPtsWorld] = useState<[number, number, number][]>([]);
   const [hoverWorld, setHoverWorld] = useState<[number, number, number] | null>(null);
   const currentPtsPxRef = useRef<Point2D[]>([]);
+  const interactionPlaneRef = useRef<Mesh>(null);
 
   const worldToPx = useCallback(
     (wx: number, wy: number): Point2D => {
@@ -42,6 +44,10 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
   );
 
   const planeArgs = useMemo<[number, number]>(() => [viewport.width, viewport.height], [viewport]);
+
+  useFrame(() => {
+    interactionPlaneRef.current?.position.set(camera.position.x, camera.position.y, -0.001);
+  });
 
   const finishStroke = useCallback(async () => {
     const ptsPx = currentPtsPxRef.current.filter(
@@ -163,6 +169,7 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
         </mesh>
       )}
       <mesh
+        ref={interactionPlaneRef}
         position={[camera.position.x, camera.position.y, -0.001]}
         onClick={onClick}
         onDoubleClick={onDoubleClick}

--- a/src/components/DrawingSurface.tsx
+++ b/src/components/DrawingSurface.tsx
@@ -85,7 +85,7 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
   const onClick = (e: { stopPropagation: () => void; pointer: { x: number; y: number } }) => {
     if (!enabled) return;
     e.stopPropagation();
-    const pointPx = pointerToModelPixel(e.pointer, size, viewport, camera.position);
+    const pointPx = pointerToModelPixel(e.pointer, size, viewport, camera.position, camera.zoom);
     const nextWorld = pxToWorld(pointPx[0], pointPx[1]);
     currentPtsPxRef.current = [...currentPtsPxRef.current, pointPx];
     setCurrentPtsWorld((prev) => [...prev, nextWorld]);
@@ -94,7 +94,7 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
 
   const onPointerMove = (e: { pointer: { x: number; y: number } }) => {
     if (!enabled) return;
-    const pointPx = pointerToModelPixel(e.pointer, size, viewport, camera.position);
+    const pointPx = pointerToModelPixel(e.pointer, size, viewport, camera.position, camera.zoom);
     setHoverWorld(pxToWorld(pointPx[0], pointPx[1]));
   };
 

--- a/src/components/DrawingSurface.tsx
+++ b/src/components/DrawingSurface.tsx
@@ -8,6 +8,7 @@ import {
   isPolygonCloseCandidate,
   type Point2D,
 } from "../lib/geometry";
+import { pointerToModelPixel } from "../lib/canvasCoordinates";
 
 interface DrawingSurfaceProps {
   onFinish: (ptsPx: Point2D[], type: "line" | "polygon") => void | Promise<void>;
@@ -17,7 +18,7 @@ interface DrawingSurfaceProps {
 }
 
 export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfaceProps) {
-  const { size, viewport } = useThree();
+  const { camera, size, viewport } = useThree();
   const [currentPtsWorld, setCurrentPtsWorld] = useState<[number, number, number][]>([]);
   const [hoverWorld, setHoverWorld] = useState<[number, number, number] | null>(null);
   const currentPtsPxRef = useRef<Point2D[]>([]);
@@ -28,6 +29,15 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
       const y = ((viewport.height / 2 - wy) / viewport.height) * size.height;
       return [x, y];
     },
+    [size.height, size.width, viewport.height, viewport.width]
+  );
+
+  const pxToWorld = useCallback(
+    (x: number, y: number): [number, number, number] => [
+      (x / size.width) * viewport.width - viewport.width / 2,
+      viewport.height / 2 - (y / size.height) * viewport.height,
+      0,
+    ],
     [size.height, size.width, viewport.height, viewport.width]
   );
 
@@ -66,19 +76,20 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
     setHoverWorld(null);
   }, [enabled]);
 
-  const onClick = (e: { stopPropagation: () => void; point: { x: number; y: number; z: number } }) => {
+  const onClick = (e: { stopPropagation: () => void; pointer: { x: number; y: number } }) => {
     if (!enabled) return;
     e.stopPropagation();
-    const p = e.point;
-    const nextWorld: [number, number, number] = [p.x, p.y, 0];
-    currentPtsPxRef.current = [...currentPtsPxRef.current, worldToPx(p.x, p.y)];
+    const pointPx = pointerToModelPixel(e.pointer, size, viewport, camera.position);
+    const nextWorld = pxToWorld(pointPx[0], pointPx[1]);
+    currentPtsPxRef.current = [...currentPtsPxRef.current, pointPx];
     setCurrentPtsWorld((prev) => [...prev, nextWorld]);
     setHoverWorld(nextWorld);
   };
 
-  const onPointerMove = (e: { point: { x: number; y: number; z: number } }) => {
+  const onPointerMove = (e: { pointer: { x: number; y: number } }) => {
     if (!enabled) return;
-    setHoverWorld([e.point.x, e.point.y, 0]);
+    const pointPx = pointerToModelPixel(e.pointer, size, viewport, camera.position);
+    setHoverWorld(pxToWorld(pointPx[0], pointPx[1]));
   };
 
   const onDoubleClick = async (e: { stopPropagation: () => void }) => {
@@ -151,7 +162,12 @@ export function DrawingSurface({ onFinish, color, width, enabled }: DrawingSurfa
           <meshBasicMaterial color={color} />
         </mesh>
       )}
-      <mesh position={[0, 0, -0.001]} onClick={onClick} onDoubleClick={onDoubleClick} onPointerMove={onPointerMove}>
+      <mesh
+        position={[camera.position.x, camera.position.y, -0.001]}
+        onClick={onClick}
+        onDoubleClick={onDoubleClick}
+        onPointerMove={onPointerMove}
+      >
         <planeGeometry args={planeArgs} />
         <meshBasicMaterial transparent opacity={0} />
       </mesh>

--- a/src/components/PanControls.tsx
+++ b/src/components/PanControls.tsx
@@ -20,6 +20,8 @@ export function PanControls({ enabled }: PanControlsProps) {
     if (!restored) return;
 
     camera.position.set(restored.cameraX, restored.cameraY, camera.position.z);
+    camera.zoom = restored.zoom;
+    camera.updateProjectionMatrix();
     controls.target.set(restored.targetX, restored.targetY, controls.target.z);
     controls.update();
   }, [camera]);
@@ -33,6 +35,7 @@ export function PanControls({ enabled }: PanControlsProps) {
       cameraY: camera.position.y,
       targetX: controls.target.x,
       targetY: controls.target.y,
+      zoom: camera.zoom,
     });
   };
 

--- a/src/components/PanControls.tsx
+++ b/src/components/PanControls.tsx
@@ -1,0 +1,49 @@
+import { useLayoutEffect, useRef, type ComponentRef } from "react";
+import { useThree } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import * as THREE from "three";
+import { loadViewportState, saveViewportState } from "../lib/viewportState";
+
+interface PanControlsProps {
+  enabled: boolean;
+}
+
+export function PanControls({ enabled }: PanControlsProps) {
+  const camera = useThree((state) => state.camera);
+  const controlsRef = useRef<ComponentRef<typeof OrbitControls>>(null);
+
+  useLayoutEffect(() => {
+    const controls = controlsRef.current;
+    if (!controls) return;
+
+    const restored = loadViewportState(window.localStorage);
+    if (!restored) return;
+
+    camera.position.set(restored.cameraX, restored.cameraY, camera.position.z);
+    controls.target.set(restored.targetX, restored.targetY, controls.target.z);
+    controls.update();
+  }, [camera]);
+
+  const persistViewport = () => {
+    const controls = controlsRef.current;
+    if (!controls) return;
+
+    saveViewportState(window.localStorage, {
+      cameraX: camera.position.x,
+      cameraY: camera.position.y,
+      targetX: controls.target.x,
+      targetY: controls.target.y,
+    });
+  };
+
+  return (
+    <OrbitControls
+      ref={controlsRef}
+      makeDefault
+      enableRotate={false}
+      enabled={enabled}
+      mouseButtons={{ LEFT: THREE.MOUSE.PAN, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN }}
+      onChange={persistViewport}
+    />
+  );
+}

--- a/src/lib/canvasCoordinates.test.ts
+++ b/src/lib/canvasCoordinates.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { pointerToModelPixel } from "./canvasCoordinates";
+
+describe("canvas coordinates", () => {
+  it("Panしていないpointerをcanvas pixelへ変換する", () => {
+    const [x, y] = pointerToModelPixel(
+      { x: -0.8, y: 2 / 3 },
+      { width: 1000, height: 600 },
+      { width: 1000, height: 600 },
+      { x: 0, y: 0 }
+    );
+
+    expect(x).toBeCloseTo(100);
+    expect(y).toBeCloseTo(100);
+  });
+
+  it("camera offsetをmodel pixelへ一度だけ反映する", () => {
+    const [x, y] = pointerToModelPixel(
+      { x: -0.8, y: 2 / 3 },
+      { width: 1000, height: 600 },
+      { width: 1000, height: 600 },
+      { x: -150, y: 60 }
+    );
+
+    expect(x).toBeCloseTo(-50);
+    expect(y).toBeCloseTo(40);
+  });
+});

--- a/src/lib/canvasCoordinates.test.ts
+++ b/src/lib/canvasCoordinates.test.ts
@@ -7,7 +7,8 @@ describe("canvas coordinates", () => {
       { x: -0.8, y: 2 / 3 },
       { width: 1000, height: 600 },
       { width: 1000, height: 600 },
-      { x: 0, y: 0 }
+      { x: 0, y: 0 },
+      1
     );
 
     expect(x).toBeCloseTo(100);
@@ -19,10 +20,28 @@ describe("canvas coordinates", () => {
       { x: -0.8, y: 2 / 3 },
       { width: 1000, height: 600 },
       { width: 1000, height: 600 },
-      { x: -150, y: 60 }
+      { x: -150, y: 60 },
+      1
     );
 
     expect(x).toBeCloseTo(-50);
     expect(y).toBeCloseTo(40);
+  });
+
+  it.each([
+    ["zoom out", 0.5, 1000, 600],
+    ["default zoom", 1, 750, 450],
+    ["zoom in", 2, 625, 375],
+  ])("%sではcanvas中心からのoffsetをzoomで割る", (_label, zoom, expectedX, expectedY) => {
+    const [x, y] = pointerToModelPixel(
+      { x: 0.5, y: -0.5 },
+      { width: 1000, height: 600 },
+      { width: 1000, height: 600 },
+      { x: 0, y: 0 },
+      zoom
+    );
+
+    expect(x).toBeCloseTo(expectedX);
+    expect(y).toBeCloseTo(expectedY);
   });
 });

--- a/src/lib/canvasCoordinates.ts
+++ b/src/lib/canvasCoordinates.ts
@@ -1,0 +1,25 @@
+import type { Point2D } from "../domain/geometryFeature";
+
+interface Vector2Like {
+  x: number;
+  y: number;
+}
+
+interface Size2D {
+  width: number;
+  height: number;
+}
+
+export const pointerToModelPixel = (
+  pointer: Vector2Like,
+  size: Size2D,
+  viewport: Size2D,
+  cameraPosition: Vector2Like
+): Point2D => {
+  const screenX = ((pointer.x + 1) / 2) * size.width;
+  const screenY = ((1 - pointer.y) / 2) * size.height;
+  const cameraOffsetX = (cameraPosition.x / viewport.width) * size.width;
+  const cameraOffsetY = (cameraPosition.y / viewport.height) * size.height;
+
+  return [screenX + cameraOffsetX, screenY - cameraOffsetY];
+};

--- a/src/lib/canvasCoordinates.ts
+++ b/src/lib/canvasCoordinates.ts
@@ -14,12 +14,15 @@ export const pointerToModelPixel = (
   pointer: Vector2Like,
   size: Size2D,
   viewport: Size2D,
-  cameraPosition: Vector2Like
+  cameraPosition: Vector2Like,
+  zoom: number
 ): Point2D => {
-  const screenX = ((pointer.x + 1) / 2) * size.width;
-  const screenY = ((1 - pointer.y) / 2) * size.height;
+  const centerX = size.width / 2;
+  const centerY = size.height / 2;
+  const pointerOffsetX = (pointer.x * size.width) / (2 * zoom);
+  const pointerOffsetY = (pointer.y * size.height) / (2 * zoom);
   const cameraOffsetX = (cameraPosition.x / viewport.width) * size.width;
   const cameraOffsetY = (cameraPosition.y / viewport.height) * size.height;
 
-  return [screenX + cameraOffsetX, screenY - cameraOffsetY];
+  return [centerX + pointerOffsetX + cameraOffsetX, centerY - pointerOffsetY - cameraOffsetY];
 };

--- a/src/lib/viewportState.test.ts
+++ b/src/lib/viewportState.test.ts
@@ -4,7 +4,7 @@ import { loadViewportState, saveViewportState, VIEWPORT_STATE_STORAGE_KEY } from
 describe("viewport state", () => {
   it("finiteなcameraとtargetを復元する", () => {
     const storage = {
-      getItem: vi.fn(() => JSON.stringify({ cameraX: 12, cameraY: -8, targetX: 12, targetY: -8 })),
+      getItem: vi.fn(() => JSON.stringify({ cameraX: 12, cameraY: -8, targetX: 12, targetY: -8, zoom: 1.5 })),
     };
 
     expect(loadViewportState(storage)).toEqual({
@@ -12,8 +12,23 @@ describe("viewport state", () => {
       cameraY: -8,
       targetX: 12,
       targetY: -8,
+      zoom: 1.5,
     });
     expect(storage.getItem).toHaveBeenCalledWith(VIEWPORT_STATE_STORAGE_KEY);
+  });
+
+  it("zoomがない旧形式をzoom 1として復元する", () => {
+    const storage = {
+      getItem: () => JSON.stringify({ cameraX: 12, cameraY: -8, targetX: 12, targetY: -8 }),
+    };
+
+    expect(loadViewportState(storage)).toEqual({
+      cameraX: 12,
+      cameraY: -8,
+      targetX: 12,
+      targetY: -8,
+      zoom: 1,
+    });
   });
 
   it.each([
@@ -21,6 +36,9 @@ describe("viewport state", () => {
     ["malformed JSON", "{"],
     ["missing property", JSON.stringify({ cameraX: 1, cameraY: 2, targetX: 3 })],
     ["non-finite property", JSON.stringify({ cameraX: 1, cameraY: 2, targetX: 3, targetY: "NaN" })],
+    ["zero zoom", JSON.stringify({ cameraX: 1, cameraY: 2, targetX: 3, targetY: 4, zoom: 0 })],
+    ["negative zoom", JSON.stringify({ cameraX: 1, cameraY: 2, targetX: 3, targetY: 4, zoom: -1 })],
+    ["invalid zoom", JSON.stringify({ cameraX: 1, cameraY: 2, targetX: 3, targetY: 4, zoom: "NaN" })],
   ])("%sのviewport stateを無視する", (_label, value) => {
     expect(loadViewportState({ getItem: () => value })).toBeNull();
   });
@@ -37,7 +55,7 @@ describe("viewport state", () => {
 
   it("viewport stateを保存する", () => {
     const storage = { setItem: vi.fn() };
-    const state = { cameraX: 4, cameraY: 5, targetX: 6, targetY: 7 };
+    const state = { cameraX: 4, cameraY: 5, targetX: 6, targetY: 7, zoom: 2 };
 
     saveViewportState(storage, state);
 
@@ -52,7 +70,7 @@ describe("viewport state", () => {
             throw new Error("blocked");
           },
         },
-        { cameraX: 4, cameraY: 5, targetX: 6, targetY: 7 }
+        { cameraX: 4, cameraY: 5, targetX: 6, targetY: 7, zoom: 2 }
       )
     ).not.toThrow();
   });

--- a/src/lib/viewportState.test.ts
+++ b/src/lib/viewportState.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadViewportState, saveViewportState, VIEWPORT_STATE_STORAGE_KEY } from "./viewportState";
+
+describe("viewport state", () => {
+  it("finiteなcameraとtargetを復元する", () => {
+    const storage = {
+      getItem: vi.fn(() => JSON.stringify({ cameraX: 12, cameraY: -8, targetX: 12, targetY: -8 })),
+    };
+
+    expect(loadViewportState(storage)).toEqual({
+      cameraX: 12,
+      cameraY: -8,
+      targetX: 12,
+      targetY: -8,
+    });
+    expect(storage.getItem).toHaveBeenCalledWith(VIEWPORT_STATE_STORAGE_KEY);
+  });
+
+  it.each([
+    ["missing", null],
+    ["malformed JSON", "{"],
+    ["missing property", JSON.stringify({ cameraX: 1, cameraY: 2, targetX: 3 })],
+    ["non-finite property", JSON.stringify({ cameraX: 1, cameraY: 2, targetX: 3, targetY: "NaN" })],
+  ])("%sのviewport stateを無視する", (_label, value) => {
+    expect(loadViewportState({ getItem: () => value })).toBeNull();
+  });
+
+  it("Storageの読み取り例外を無視する", () => {
+    expect(
+      loadViewportState({
+        getItem: () => {
+          throw new Error("blocked");
+        },
+      })
+    ).toBeNull();
+  });
+
+  it("viewport stateを保存する", () => {
+    const storage = { setItem: vi.fn() };
+    const state = { cameraX: 4, cameraY: 5, targetX: 6, targetY: 7 };
+
+    saveViewportState(storage, state);
+
+    expect(storage.setItem).toHaveBeenCalledWith(VIEWPORT_STATE_STORAGE_KEY, JSON.stringify(state));
+  });
+
+  it("Storageの書き込み例外を無視する", () => {
+    expect(() =>
+      saveViewportState(
+        {
+          setItem: () => {
+            throw new Error("blocked");
+          },
+        },
+        { cameraX: 4, cameraY: 5, targetX: 6, targetY: 7 }
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/lib/viewportState.ts
+++ b/src/lib/viewportState.ts
@@ -1,0 +1,52 @@
+export const VIEWPORT_STATE_STORAGE_KEY = "vite-react-three:viewport";
+
+export interface ViewportState {
+  cameraX: number;
+  cameraY: number;
+  targetX: number;
+  targetY: number;
+}
+
+interface ReadableStorage {
+  getItem(key: string): string | null;
+}
+
+interface WritableStorage {
+  setItem(key: string, value: string): void;
+}
+
+const isFiniteNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
+
+export const loadViewportState = (storage: ReadableStorage): ViewportState | null => {
+  try {
+    const value = storage.getItem(VIEWPORT_STATE_STORAGE_KEY);
+    if (value === null) return null;
+
+    const parsed = JSON.parse(value) as Partial<ViewportState>;
+    if (
+      !isFiniteNumber(parsed.cameraX) ||
+      !isFiniteNumber(parsed.cameraY) ||
+      !isFiniteNumber(parsed.targetX) ||
+      !isFiniteNumber(parsed.targetY)
+    ) {
+      return null;
+    }
+
+    return {
+      cameraX: parsed.cameraX,
+      cameraY: parsed.cameraY,
+      targetX: parsed.targetX,
+      targetY: parsed.targetY,
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const saveViewportState = (storage: WritableStorage, state: ViewportState): void => {
+  try {
+    storage.setItem(VIEWPORT_STATE_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Viewport persistence is optional and must not block geometry work.
+  }
+};

--- a/src/lib/viewportState.ts
+++ b/src/lib/viewportState.ts
@@ -5,6 +5,7 @@ export interface ViewportState {
   cameraY: number;
   targetX: number;
   targetY: number;
+  zoom: number;
 }
 
 interface ReadableStorage {
@@ -32,11 +33,15 @@ export const loadViewportState = (storage: ReadableStorage): ViewportState | nul
       return null;
     }
 
+    const zoom = parsed.zoom === undefined ? 1 : parsed.zoom;
+    if (!isFiniteNumber(zoom) || zoom <= 0) return null;
+
     return {
       cameraX: parsed.cameraX,
       cameraY: parsed.cameraY,
       targetX: parsed.targetX,
       targetY: parsed.targetY,
+      zoom,
     };
   } catch {
     return null;

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -136,7 +136,7 @@ test.describe("drawing workspace", () => {
     await expect(page.getByText("Length: 215.4 px")).toBeVisible();
   });
 
-  test("Pan後の座標とviewportをreload後も保持する", async ({ page }) => {
+  test("PanとZoom後のviewportをreload直後のDrawでも保持する", async ({ page }) => {
     test.setTimeout(90_000);
     await gotoApp(page);
     const box = await getCanvasBox(page);
@@ -156,8 +156,15 @@ test.describe("drawing workspace", () => {
     await expect(page.getByRole("button", { name: "Pan" })).toHaveAttribute("aria-pressed", "true");
     await page.mouse.move(box.x + box.width * 0.5, box.y + box.height * 0.5);
     await page.mouse.down();
-    await page.mouse.move(box.x + box.width * 0.65, box.y + box.height * 0.6, { steps: 8 });
+    await page.mouse.move(box.x + box.width * 0.85, box.y + box.height * 0.75, { steps: 12 });
     await page.mouse.up();
+    await page.mouse.wheel(0, 500);
+    const zoomBeforeReload = await page.evaluate(() => {
+      const value = window.localStorage.getItem("vite-react-three:viewport");
+      return value ? (JSON.parse(value) as { zoom?: number }).zoom : undefined;
+    });
+    expect(zoomBeforeReload).toBeDefined();
+    expect(zoomBeforeReload).not.toBe(1);
 
     await page.getByRole("button", { name: "Measure" }).click();
     await expect(measurement).toBeVisible();
@@ -182,6 +189,17 @@ test.describe("drawing workspace", () => {
 
     await page.reload();
     await expect(page.getByTestId("loading-overlay")).toBeHidden({ timeout: 30_000 });
+    const zoomAfterReload = await page.evaluate(() => {
+      const value = window.localStorage.getItem("vite-react-three:viewport");
+      return value ? (JSON.parse(value) as { zoom?: number }).zoom : undefined;
+    });
+    expect(zoomAfterReload).toBeCloseTo(zoomBeforeReload ?? 1);
+
+    await page.mouse.click(box.x + 20, box.y + 300);
+    await page.mouse.click(box.x + 100, box.y + 300);
+    await page.keyboard.press("Escape");
+    expect(await exportFeatureCount(page)).toBe(3);
+
     await page.getByRole("button", { name: "Measure" }).click();
     await expect(pannedMeasurement).toBeVisible();
     const afterReload = await pannedMeasurement.boundingBox();

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -165,6 +165,7 @@ test.describe("drawing workspace", () => {
     });
     expect(zoomBeforeReload).toBeDefined();
     expect(zoomBeforeReload).not.toBe(1);
+    if (zoomBeforeReload === undefined) throw new Error("saved zoom was not available before reload");
 
     await page.getByRole("button", { name: "Measure" }).click();
     await expect(measurement).toBeVisible();
@@ -174,13 +175,16 @@ test.describe("drawing workspace", () => {
 
     const pannedStart = { x: box.x + 100, y: box.y + 100 };
     const pannedEnd = { x: box.x + 260, y: box.y + 180 };
+    const expectedPannedLength = (Math.hypot(160, 80) / zoomBeforeReload).toFixed(1);
     await page.getByRole("button", { name: "Draw" }).click();
     await page.mouse.click(pannedStart.x, pannedStart.y);
+    await page.mouse.move(pannedEnd.x, pannedEnd.y);
+    await expect(page.getByText(`Length: ${expectedPannedLength} px`)).toBeVisible();
     await page.mouse.click(pannedEnd.x, pannedEnd.y);
     await page.keyboard.press("Escape");
 
     await page.getByRole("button", { name: "Measure" }).click();
-    const pannedMeasurement = page.getByText("Length: 178.9 px");
+    const pannedMeasurement = page.getByText(`Length: ${expectedPannedLength} px`);
     await expect(pannedMeasurement).toBeVisible();
     const afterDraw = await pannedMeasurement.boundingBox();
     if (!afterDraw) throw new Error("panned measurement bounding box was not available before reload");
@@ -193,7 +197,7 @@ test.describe("drawing workspace", () => {
       const value = window.localStorage.getItem("vite-react-three:viewport");
       return value ? (JSON.parse(value) as { zoom?: number }).zoom : undefined;
     });
-    expect(zoomAfterReload).toBeCloseTo(zoomBeforeReload ?? 1);
+    expect(zoomAfterReload).toBeCloseTo(zoomBeforeReload);
 
     await page.mouse.click(box.x + 20, box.y + 300);
     await page.mouse.click(box.x + 100, box.y + 300);

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -136,7 +136,8 @@ test.describe("drawing workspace", () => {
     await expect(page.getByText("Length: 215.4 px")).toBeVisible();
   });
 
-  test("Panはviewportを移動し新しいgeometryを作らない", async ({ page }) => {
+  test("Pan後の座標とviewportをreload後も保持する", async ({ page }) => {
+    test.setTimeout(90_000);
     await gotoApp(page);
     const box = await getCanvasBox(page);
     await page.getByRole("button", { name: "Clear" }).click();
@@ -164,7 +165,28 @@ test.describe("drawing workspace", () => {
     if (!afterPan) throw new Error("measurement bounding box was not available after pan");
     expect(Math.hypot(afterPan.x - beforePan.x, afterPan.y - beforePan.y)).toBeGreaterThan(20);
 
-    expect(await exportFeatureCount(page)).toBe(1);
+    const pannedStart = { x: box.x + 100, y: box.y + 100 };
+    const pannedEnd = { x: box.x + 260, y: box.y + 180 };
+    await page.getByRole("button", { name: "Draw" }).click();
+    await page.mouse.click(pannedStart.x, pannedStart.y);
+    await page.mouse.click(pannedEnd.x, pannedEnd.y);
+    await page.keyboard.press("Escape");
+
+    await page.getByRole("button", { name: "Measure" }).click();
+    const pannedMeasurement = page.getByText("Length: 178.9 px");
+    await expect(pannedMeasurement).toBeVisible();
+    const afterDraw = await pannedMeasurement.boundingBox();
+    if (!afterDraw) throw new Error("panned measurement bounding box was not available before reload");
+
+    expect(await exportFeatureCount(page)).toBe(2);
+
+    await page.reload();
+    await expect(page.getByTestId("loading-overlay")).toBeHidden({ timeout: 30_000 });
+    await page.getByRole("button", { name: "Measure" }).click();
+    await expect(pannedMeasurement).toBeVisible();
+    const afterReload = await pannedMeasurement.boundingBox();
+    if (!afterReload) throw new Error("measurement bounding box was not available after reload");
+    expect(Math.hypot(afterReload.x - afterDraw.x, afterReload.y - afterDraw.y)).toBeLessThanOrEqual(2);
   });
 
   test("Clearしたgeometryはrefreshとreload後にも復元されない", async ({ page }) => {

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -18,7 +18,20 @@ const getCanvasBox = async (page: Page) => {
   return box;
 };
 
+const exportFeatureCount = async (page: Page) => {
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Export GeoJSON" }).click();
+  const download = await downloadPromise;
+  const stream = await download.createReadStream();
+  let text = "";
+  for await (const chunk of stream) text += chunk.toString();
+  const collection = JSON.parse(text) as { features: unknown[] };
+  return collection.features.length;
+};
+
 test.describe("drawing workspace", () => {
+  test.describe.configure({ mode: "serial" });
+
   test("DuckDB初期化中はGeoJSON exportを無効にする", async ({ page }) => {
     await page.goto("./", { waitUntil: "domcontentloaded" });
 
@@ -87,6 +100,93 @@ test.describe("drawing workspace", () => {
     await expect(page.getByText("Length: 161.2 px")).toBeVisible();
 
     await page.getByRole("button", { name: "Undo" }).click();
+    await expect(page.getByText(/Length: \d+\.\d px/)).toHaveCount(0);
+  });
+
+  test("編集したlineをrefreshとreload後に復元する", async ({ page }) => {
+    test.setTimeout(90_000);
+    await gotoApp(page);
+    const box = await getCanvasBox(page);
+    await page.getByRole("button", { name: "Clear" }).click();
+
+    const start = { x: box.x + 100, y: box.y + 100 };
+    const originalEnd = { x: box.x + 240, y: box.y + 180 };
+    const editedEnd = { x: box.x + 300, y: box.y + 180 };
+    await page.mouse.click(start.x, start.y);
+    await page.mouse.click(originalEnd.x, originalEnd.y);
+    await page.keyboard.press("Escape");
+
+    await page.getByRole("button", { name: "Measure" }).click();
+    await expect(page.getByText("Length: 161.2 px")).toBeVisible();
+
+    await page.getByRole("button", { name: "Edit" }).click();
+    await page.mouse.move(originalEnd.x, originalEnd.y);
+    await page.mouse.down();
+    await page.mouse.move(editedEnd.x, editedEnd.y, { steps: 8 });
+    await page.mouse.up();
+
+    await page.getByRole("button", { name: "Measure" }).click();
+    await expect(page.getByText("Length: 215.4 px")).toBeVisible();
+    await page.getByRole("button", { name: "Refresh" }).click();
+    await expect(page.getByText("Length: 215.4 px")).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByTestId("loading-overlay")).toBeHidden({ timeout: 30_000 });
+    await page.getByRole("button", { name: "Measure" }).click();
+    await expect(page.getByText("Length: 215.4 px")).toBeVisible();
+  });
+
+  test("Panはviewportを移動し新しいgeometryを作らない", async ({ page }) => {
+    await gotoApp(page);
+    const box = await getCanvasBox(page);
+    await page.getByRole("button", { name: "Clear" }).click();
+
+    await page.mouse.click(box.x + 100, box.y + 100);
+    await page.mouse.click(box.x + 240, box.y + 180);
+    await page.keyboard.press("Escape");
+    await page.getByRole("button", { name: "Measure" }).click();
+
+    const measurement = page.getByText("Length: 161.2 px");
+    await expect(measurement).toBeVisible();
+    const beforePan = await measurement.boundingBox();
+    if (!beforePan) throw new Error("measurement bounding box was not available before pan");
+
+    await page.getByRole("button", { name: "Pan" }).click();
+    await expect(page.getByRole("button", { name: "Pan" })).toHaveAttribute("aria-pressed", "true");
+    await page.mouse.move(box.x + box.width * 0.5, box.y + box.height * 0.5);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width * 0.65, box.y + box.height * 0.6, { steps: 8 });
+    await page.mouse.up();
+
+    await page.getByRole("button", { name: "Measure" }).click();
+    await expect(measurement).toBeVisible();
+    const afterPan = await measurement.boundingBox();
+    if (!afterPan) throw new Error("measurement bounding box was not available after pan");
+    expect(Math.hypot(afterPan.x - beforePan.x, afterPan.y - beforePan.y)).toBeGreaterThan(20);
+
+    expect(await exportFeatureCount(page)).toBe(1);
+  });
+
+  test("Clearしたgeometryはrefreshとreload後にも復元されない", async ({ page }) => {
+    test.setTimeout(90_000);
+    await gotoApp(page);
+    const box = await getCanvasBox(page);
+    await page.getByRole("button", { name: "Clear" }).click();
+
+    await page.mouse.click(box.x + 100, box.y + 100);
+    await page.mouse.click(box.x + 240, box.y + 180);
+    await page.keyboard.press("Escape");
+    await page.getByRole("button", { name: "Measure" }).click();
+    await expect(page.getByText("Length: 161.2 px")).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear" }).click();
+    await expect(page.getByText(/Length: \d+\.\d px/)).toHaveCount(0);
+    await page.getByRole("button", { name: "Refresh" }).click();
+    await expect(page.getByText(/Length: \d+\.\d px/)).toHaveCount(0);
+
+    await page.reload();
+    await expect(page.getByTestId("loading-overlay")).toBeHidden({ timeout: 30_000 });
+    await page.getByRole("button", { name: "Measure" }).click();
     await expect(page.getByText(/Length: \d+\.\d px/)).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## 概要

Phase 0の残作業だったブラウザ操作カバレッジを完成させ、ROADMAPをGit追跡へ追加します。

## 変更内容

- edit後のgeometryがRefreshとReload後にも維持されるE2Eを追加
- Pan操作でviewportが移動し、geometryが増えないことを検証
- Clear後のgeometryがRefreshとReloadで復活しないことを検証
- OPFSを共有するstateful E2Eをserial実行に固定
- `ROADMAP.md`を追加し、Phase 0の完了状況とブラウザ操作カバレッジ表を記録
- Panモードの左ドラッグを`THREE.MOUSE.PAN`へ割り当て

## 背景・原因

Phase 0ではdraw、edit、measure、pan、undo、clear、refresh、GeoJSON import/exportのブラウザ検証が完了条件でした。既存テストではedit persistence、Pan、Clear persistenceが未確認でした。

追加した実操作テストにより、`OrbitControls`で回転を無効化していても左ドラッグが既定のRotate操作へ割り当てられたままで、UI案内どおりにPanできない問題が判明しました。左ドラッグを明示的にPanへ割り当てて修正しています。

## 影響

- Draw/Edit/Measure/Panの主要操作がdesktop/mobileで回帰検証されます。
- 保存、編集、削除のOPFS永続化境界がブラウザテストで固定されます。
- Phase 1へ進む前提となるPhase 0の完了状態がROADMAPで明確になります。

## 検証

- `npm test` — 89 tests passed
- `npm run test:e2e` — 20 tests passed（desktop/mobile）
- `npm run lint` — passed
- `npm run build` — passed
- Prettier / `git diff --check` — passed

既知の警告として、Viteのlarge chunk warningとDuckDB WASMのmissing sourcemap warningがあります。