### PR TITLE
feat: complete Phase 1 DuckDB Spatial Lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 playwright-report
 test-results
 .codex-artifacts/
+backlog/
 *.local
 
 # Editor directories and files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ Core files:
 
 The Vite dev server sets `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers because DuckDB WASM can require cross-origin isolation.
 
+## Git Workflow
+
+- Before making implementation changes, create or switch to a task-specific feature branch. Do not begin implementation work directly on `main`.
+
 ## Coding Notes
 
 - Keep coordinate storage in pixel coordinates (`Point2D`) unless changing the persistence model intentionally.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ The Vite dev server sets `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder
 
 - Keep coordinate storage in pixel coordinates (`Point2D`) unless changing the persistence model intentionally.
 - Preserve the fallback JSON table path for environments where the DuckDB spatial extension cannot load.
+- Treat desktop browsers as the supported UI target. Mobile layout and mobile E2E coverage are not required.
 - Prefer extending `src/lib/geometry.ts` for pure geometry behavior and test those helpers directly when a test runner is added.
 - Avoid unrelated UI refactors when changing drawing, measurement, or persistence behavior.
 - When changing canvas interactions, verify draw, edit, measure, pan, undo, clear, refresh, and GeoJSON import/export paths as applicable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ The Vite dev server sets `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder
 
 - Keep coordinate storage in pixel coordinates (`Point2D`) unless changing the persistence model intentionally.
 - Preserve the fallback JSON table path for environments where the DuckDB spatial extension cannot load.
-- Treat desktop browsers as the supported UI target. Mobile layout and mobile E2E coverage are not required.
+- This remains a browser-based Vite web app; do not introduce Electron, Tauri, native packaging, or other desktop-app infrastructure.
+- Treat PC-sized browser viewports as the supported UI target. Mobile layout and mobile E2E coverage are not required.
 - Prefer extending `src/lib/geometry.ts` for pure geometry behavior and test those helpers directly when a test runner is added.
 - Avoid unrelated UI refactors when changing drawing, measurement, or persistence behavior.
 - When changing canvas interactions, verify draw, edit, measure, pan, undo, clear, refresh, and GeoJSON import/export paths as applicable.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Scene } from "./components/Scene";
 import { DrawingSurface } from "./components/DrawingSurface";
 import { StrokeEditor } from "./components/StrokeEditor";
 import { PanControls } from "./components/PanControls";
+import { SqlWorkbench } from "./components/SqlWorkbench";
 import type { RenderableStroke } from "./domain/renderableStroke";
 import { useGeometryFeatures, type StorageStatus } from "./hooks/useGeometryFeatures";
 import type { Point2D } from "./domain/geometryFeature";
@@ -131,12 +132,14 @@ export default function App() {
   const [simplifyOn, setSimplifyOn] = useState(true);
   const {
     canExport,
+    features,
     handleClear,
     handleExportGeoJSON,
     handleImportGeoJSON,
     handleRefresh,
     handleUndo,
     loading,
+    layers,
     operationNotice,
     persistStroke,
     storageStatus,
@@ -172,17 +175,20 @@ export default function App() {
         handleImportGeoJSON={handleImportGeoJSON}
       />
 
-      <Workspace
-        interactionMode={interactionMode}
-        loading={loading}
-        operationNotice={operationNotice}
-        storageStatus={storageStatus}
-        strokeColor={strokeColor}
-        strokeWidth={strokeWidth}
-        strokes={strokes}
-        onFinishStroke={persistStroke}
-        onUpdateStroke={updateStroke}
-      />
+      <div className="workbench-layout">
+        <Workspace
+          interactionMode={interactionMode}
+          loading={loading}
+          operationNotice={operationNotice}
+          storageStatus={storageStatus}
+          strokeColor={strokeColor}
+          strokeWidth={strokeWidth}
+          strokes={strokes}
+          onFinishStroke={persistStroke}
+          onUpdateStroke={updateStroke}
+        />
+        <SqlWorkbench features={features} layers={layers} storageLoading={loading} />
+      </div>
 
       <StatusFooter storageStatus={storageStatus} />
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,6 +144,7 @@ export default function App() {
     loading,
     layers,
     operationNotice,
+    promoteQueryResult,
     persistStroke,
     storageStatus,
     strokes,
@@ -192,7 +193,12 @@ export default function App() {
           onFinishStroke={persistStroke}
           onUpdateStroke={updateStroke}
         />
-        <SqlWorkbench query={query} />
+        <SqlWorkbench
+          query={query}
+          onPromote={(layerName) =>
+            query.result ? promoteQueryResult(query.result, layerName) : Promise.resolve({ status: "empty" as const })
+          }
+        />
       </div>
 
       <StatusFooter storageStatus={storageStatus} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { SqlWorkbench } from "./components/SqlWorkbench";
 import type { RenderableStroke } from "./domain/renderableStroke";
 import { useGeometryFeatures, type StorageStatus } from "./hooks/useGeometryFeatures";
 import type { Point2D } from "./domain/geometryFeature";
+import { useQueryWorkbench } from "./hooks/useQueryWorkbench";
 
 type InteractionMode = "draw" | "pan" | "edit" | "measure";
 
@@ -20,6 +21,7 @@ interface WorkspaceProps {
   strokeColor: string;
   strokeWidth: number;
   strokes: RenderableStroke[];
+  temporaryStrokes: RenderableStroke[];
   onFinishStroke: ReturnType<typeof useGeometryFeatures>["persistStroke"];
   onUpdateStroke: (strokeId: string, newPtsPx: Point2D[]) => Promise<void>;
 }
@@ -32,6 +34,7 @@ function Workspace({
   strokeColor,
   strokeWidth,
   strokes,
+  temporaryStrokes,
   onFinishStroke,
   onUpdateStroke,
 }: WorkspaceProps) {
@@ -50,7 +53,7 @@ function Workspace({
             <PanControls enabled={interactionMode === "pan"} />
 
             <Scene
-              strokes={strokes}
+              strokes={[...strokes, ...temporaryStrokes]}
               hideStrokes={interactionMode === "edit"}
               showMeasurements={interactionMode === "measure"}
             />
@@ -146,6 +149,7 @@ export default function App() {
     strokes,
     updateStroke,
   } = useGeometryFeatures(strokeColor, strokeWidth, simplifyOn);
+  const query = useQueryWorkbench(features, layers, loading);
 
   return (
     <div
@@ -184,10 +188,11 @@ export default function App() {
           strokeColor={strokeColor}
           strokeWidth={strokeWidth}
           strokes={strokes}
+          temporaryStrokes={query.temporaryStrokes}
           onFinishStroke={persistStroke}
           onUpdateStroke={updateStroke}
         />
-        <SqlWorkbench features={features} layers={layers} storageLoading={loading} />
+        <SqlWorkbench query={query} />
       </div>
 
       <StatusFooter storageStatus={storageStatus} />

--- a/src/components/SqlWorkbench.tsx
+++ b/src/components/SqlWorkbench.tsx
@@ -1,19 +1,11 @@
-import { SQL_EXAMPLES, useQueryWorkbench } from "../hooks/useQueryWorkbench";
-import type { GeometryFeature, Layer } from "../domain/geometryFeature";
+import { SQL_EXAMPLES, type useQueryWorkbench } from "../hooks/useQueryWorkbench";
 
 const displayValue = (value: unknown) =>
   value === null ? "NULL" : typeof value === "object" ? JSON.stringify(value) : String(value);
 
-export function SqlWorkbench({
-  features,
-  layers,
-  storageLoading,
-}: {
-  features: GeometryFeature[];
-  layers: Layer[];
-  storageLoading: boolean;
-}) {
-  const query = useQueryWorkbench(features, layers, storageLoading);
+export function SqlWorkbench({ query }: { query: ReturnType<typeof useQueryWorkbench> }) {
+  const renderedRowIndexes = new Set(query.temporaryStrokes.map(({ id }) => Number(id.replace("query-result-", ""))));
+
   return (
     <aside className="sql-workbench" data-testid="sql-workbench">
       <div className="sql-workbench__heading">
@@ -104,7 +96,7 @@ export function SqlWorkbench({
               </thead>
               <tbody>
                 {query.result.rows.map((row, index) => (
-                  <tr key={index}>
+                  <tr key={index} data-query-geometry={renderedRowIndexes.has(index) ? "rendered" : undefined}>
                     {query.result!.columns.map((column) => (
                       <td key={column.name}>{displayValue(row[column.name])}</td>
                     ))}
@@ -114,6 +106,11 @@ export function SqlWorkbench({
             </table>
           </div>
         </section>
+      )}
+      {query.temporaryStrokes.length > 0 && (
+        <div className="query-message" data-testid="temporary-result-count">
+          {query.temporaryStrokes.length} geometries rendered temporarily
+        </div>
       )}
     </aside>
   );

--- a/src/components/SqlWorkbench.tsx
+++ b/src/components/SqlWorkbench.tsx
@@ -1,0 +1,120 @@
+import { SQL_EXAMPLES, useQueryWorkbench } from "../hooks/useQueryWorkbench";
+import type { GeometryFeature, Layer } from "../domain/geometryFeature";
+
+const displayValue = (value: unknown) =>
+  value === null ? "NULL" : typeof value === "object" ? JSON.stringify(value) : String(value);
+
+export function SqlWorkbench({
+  features,
+  layers,
+  storageLoading,
+}: {
+  features: GeometryFeature[];
+  layers: Layer[];
+  storageLoading: boolean;
+}) {
+  const query = useQueryWorkbench(features, layers, storageLoading);
+  return (
+    <aside className="sql-workbench" data-testid="sql-workbench">
+      <div className="sql-workbench__heading">
+        <div>
+          <span className="sql-workbench__eyebrow">DUCKDB SPATIAL LAB</span>
+          <h2>SQL Workbench</h2>
+        </div>
+        <span className={`query-status query-status--${query.status}`} role="status" data-testid="query-status">
+          {query.status}
+        </span>
+      </div>
+
+      <label className="sql-label" htmlFor="sql-editor">
+        Read-only query
+      </label>
+      <textarea
+        id="sql-editor"
+        data-testid="sql-editor"
+        value={query.sql}
+        onChange={(event) => query.setSql(event.target.value)}
+      />
+      <div className="sql-actions">
+        <button
+          onClick={() => void query.execute()}
+          disabled={query.status === "initializing" || query.status === "running"}
+        >
+          Run query
+        </button>
+        <button onClick={() => void query.cancel()} disabled={query.status !== "running"}>
+          Cancel
+        </button>
+      </div>
+
+      <label className="sql-label" htmlFor="sql-examples">
+        Examples
+      </label>
+      <select
+        id="sql-examples"
+        defaultValue=""
+        onChange={(event) => event.target.value && query.setSql(event.target.value)}
+      >
+        <option value="" disabled>
+          Select an example
+        </option>
+        {SQL_EXAMPLES.map((example) => (
+          <option key={example.label} value={example.sql}>
+            {example.label}
+          </option>
+        ))}
+      </select>
+
+      <label className="sql-label" htmlFor="sql-history">
+        Recent queries
+      </label>
+      <select id="sql-history" value="" onChange={(event) => event.target.value && query.setSql(event.target.value)}>
+        <option value="">Select history</option>
+        {query.history.map((entry) => (
+          <option key={entry} value={entry}>
+            {entry}
+          </option>
+        ))}
+      </select>
+
+      {query.error && (
+        <div className="query-message query-message--error" role="alert">
+          {query.error}
+        </div>
+      )}
+      {query.status === "cancelled" && <div className="query-message">Query cancelled.</div>}
+      {query.status === "empty" && <div className="query-message">Query completed with no rows.</div>}
+      {query.result && (
+        <section className="query-results" aria-label="Query results">
+          <div className="query-results__meta">
+            <span>{query.result.rowCount} rows</span>
+            <span>{query.result.truncated ? "Truncated at 1,000 rows" : "Complete result"}</span>
+          </div>
+          <div className="query-table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  {query.result.columns.map((column) => (
+                    <th key={column.name}>
+                      {column.name}
+                      <small>{column.type}</small>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {query.result.rows.map((row, index) => (
+                  <tr key={index}>
+                    {query.result!.columns.map((column) => (
+                      <td key={column.name}>{displayValue(row[column.name])}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </aside>
+  );
+}

--- a/src/components/SqlWorkbench.tsx
+++ b/src/components/SqlWorkbench.tsx
@@ -1,10 +1,37 @@
+import { useState } from "react";
 import { SQL_EXAMPLES, type useQueryWorkbench } from "../hooks/useQueryWorkbench";
+import type { QueryPromotionResult } from "../hooks/useGeometryFeatures";
 
 const displayValue = (value: unknown) =>
   value === null ? "NULL" : typeof value === "object" ? JSON.stringify(value) : String(value);
 
-export function SqlWorkbench({ query }: { query: ReturnType<typeof useQueryWorkbench> }) {
+export function SqlWorkbench({
+  query,
+  onPromote,
+}: {
+  query: ReturnType<typeof useQueryWorkbench>;
+  onPromote: (layerName: string) => Promise<QueryPromotionResult>;
+}) {
   const renderedRowIndexes = new Set(query.temporaryStrokes.map(({ id }) => Number(id.replace("query-result-", ""))));
+  const [layerName, setLayerName] = useState("Query result");
+  const [promotionMessage, setPromotionMessage] = useState<string>();
+  const [saving, setSaving] = useState(false);
+
+  const promote = async () => {
+    setSaving(true);
+    setPromotionMessage(undefined);
+    const promotion = await onPromote(layerName);
+    setSaving(false);
+    if (promotion.status === "saved") {
+      setPromotionMessage(`Saved ${promotion.count} features to “${promotion.layerName}”.`);
+    } else if (promotion.status === "invalid-name") {
+      setPromotionMessage("Enter a layer name.");
+    } else if (promotion.status === "empty") {
+      setPromotionMessage("No supported result geometry is available to save.");
+    } else {
+      setPromotionMessage("Save failed. No partial layer was kept.");
+    }
+  };
 
   return (
     <aside className="sql-workbench" data-testid="sql-workbench">
@@ -108,8 +135,30 @@ export function SqlWorkbench({ query }: { query: ReturnType<typeof useQueryWorkb
         </section>
       )}
       {query.temporaryStrokes.length > 0 && (
-        <div className="query-message" data-testid="temporary-result-count">
-          {query.temporaryStrokes.length} geometries rendered temporarily
+        <section className="query-promotion" aria-label="Save query result">
+          <div className="query-message" data-testid="temporary-result-count">
+            {query.temporaryStrokes.length} geometries rendered temporarily
+          </div>
+          <label className="sql-label" htmlFor="query-layer-name">
+            Persistent layer name
+          </label>
+          <input
+            id="query-layer-name"
+            data-testid="query-layer-name"
+            value={layerName}
+            onChange={(event) => setLayerName(event.target.value)}
+          />
+          <button type="button" onClick={() => void promote()} disabled={saving || layerName.trim().length === 0}>
+            {saving ? "Saving…" : "Save as layer"}
+          </button>
+          <small data-testid="query-promotion-duplicate-policy">
+            Saving the same result again creates a new layer with new feature IDs; existing layers are not overwritten.
+          </small>
+        </section>
+      )}
+      {promotionMessage && (
+        <div className="query-message" role="status" data-testid="query-promotion-status">
+          {promotionMessage}
         </div>
       )}
     </aside>

--- a/src/db/queryRuntime.test.ts
+++ b/src/db/queryRuntime.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { QueryRejectedError, QueryRuntime, validateReadOnlySql } from "./queryRuntime";
+
+const reader = (rows: Record<string, unknown>[], fields = [{ name: "id", type: { toString: () => "VARCHAR" } }]) => {
+  const value = {
+    schema: { fields },
+    open: vi.fn(async () => value),
+    async *[Symbol.asyncIterator]() {
+      yield { schema: { fields }, toArray: () => rows.map((row) => ({ toJSON: () => row })) };
+    },
+  };
+  return value;
+};
+
+const fixture = (readers: ReturnType<typeof reader>[]) => {
+  const connections = readers.map((value) => ({
+    send: vi.fn().mockResolvedValue(value),
+    cancelSent: vi.fn().mockResolvedValue(true),
+    close: vi.fn().mockResolvedValue(undefined),
+  }));
+  const db = {
+    connect: vi.fn(async () => {
+      const connection = connections.shift();
+      if (!connection) throw new Error("no connection");
+      return connection;
+    }),
+    terminate: vi.fn().mockResolvedValue(undefined),
+  };
+  return { db, connections };
+};
+
+describe("read-only SQL validation", () => {
+  it.each(["UPDATE x SET y=1", "DELETE FROM x", "CREATE TABLE x(i INT)", "COPY x TO 'a'", "SELECT 1; DROP TABLE x"])(
+    "rejects %s before execution",
+    (sql) => expect(() => validateReadOnlySql(sql)).toThrow(QueryRejectedError)
+  );
+
+  it("accepts one SELECT or WITH query and removes a trailing semicolon", () => {
+    expect(validateReadOnlySql(" SELECT 1; ")).toBe("SELECT 1");
+    expect(validateReadOnlySql("WITH x AS (SELECT 1) SELECT * FROM x")).toContain("WITH x");
+  });
+});
+
+describe("QueryRuntime", () => {
+  it("returns typed rows and truncates the 1001st row", async () => {
+    const rows = Array.from({ length: 1001 }, (_, index) => ({ id: BigInt(index + 1) }));
+    const { db } = fixture([reader(rows, [{ name: "id", type: { toString: () => "BIGINT" } }])]);
+    const runtime = new QueryRuntime(db);
+
+    const result = await runtime.execute("SELECT id FROM geometry_features");
+
+    expect(result).toMatchObject({
+      status: "success",
+      rowCount: 1000,
+      truncated: true,
+      columns: [{ name: "id", type: "BIGINT" }],
+    });
+    expect(result?.rows[0]).toEqual({ id: "1" });
+  });
+
+  it("distinguishes empty results and propagates invalid SQL errors", async () => {
+    const { db } = fixture([reader([]), reader([])]);
+    const runtime = new QueryRuntime(db);
+
+    await expect(runtime.execute("SELECT id FROM geometry_features WHERE false")).resolves.toMatchObject({
+      status: "empty",
+      rowCount: 0,
+    });
+    db.connect.mockResolvedValueOnce({
+      send: vi.fn().mockRejectedValue(new Error("Parser Error")),
+      cancelSent: vi.fn().mockResolvedValue(false),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+    await expect(runtime.execute("SELECT broken")).rejects.toThrow("Parser Error");
+  });
+
+  it("cancels the active connection and uses a fresh connection next time", async () => {
+    let resolveFirst!: (value: ReturnType<typeof reader>) => void;
+    const first = {
+      send: vi.fn(() => new Promise<ReturnType<typeof reader>>((resolve) => (resolveFirst = resolve))),
+      cancelSent: vi.fn().mockResolvedValue(true),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const second = {
+      send: vi.fn().mockResolvedValue(reader([{ id: "next" }])),
+      cancelSent: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const db = { connect: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second), terminate: vi.fn() };
+    const runtime = new QueryRuntime(db);
+    const pending = runtime.execute("SELECT 1");
+
+    await vi.waitFor(() => expect(first.send).toHaveBeenCalled());
+    await runtime.cancel();
+    resolveFirst(reader([{ id: "stale" }]));
+
+    await expect(pending).resolves.toBeNull();
+    await expect(runtime.execute("SELECT 2")).resolves.toMatchObject({ rows: [{ id: "next" }] });
+    expect(first.cancelSent).toHaveBeenCalledOnce();
+    expect(db.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses results after dispose", async () => {
+    let resolveQuery!: (value: ReturnType<typeof reader>) => void;
+    const connection = {
+      send: vi.fn(() => new Promise<ReturnType<typeof reader>>((resolve) => (resolveQuery = resolve))),
+      cancelSent: vi.fn().mockResolvedValue(true),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const db = { connect: vi.fn().mockResolvedValue(connection), terminate: vi.fn().mockResolvedValue(undefined) };
+    const runtime = new QueryRuntime(db);
+    const pending = runtime.execute("SELECT 1");
+    await vi.waitFor(() => expect(connection.send).toHaveBeenCalled());
+
+    await runtime.dispose();
+    resolveQuery(reader([{ id: "stale" }]));
+
+    await expect(pending).resolves.toBeNull();
+    expect(db.terminate).toHaveBeenCalledOnce();
+  });
+});

--- a/src/db/queryRuntime.ts
+++ b/src/db/queryRuntime.ts
@@ -1,0 +1,234 @@
+import * as duckdb from "@duckdb/duckdb-wasm";
+import { bundle } from "../dbBundles";
+import { initializeQueryViews, type QuerySnapshot } from "./queryViews";
+
+const QUERY_ROW_LIMIT = 1000;
+const PROHIBITED_KEYWORDS =
+  /\b(ALTER|ATTACH|CALL|CHECKPOINT|COMMENT|COPY|CREATE|DELETE|DETACH|DROP|EXPORT|IMPORT|INSERT|INSTALL|LOAD|MERGE|PRAGMA|SET|TRUNCATE|UPDATE|VACUUM)\b/i;
+
+export class QueryRejectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QueryRejectedError";
+  }
+}
+
+const scrubSql = (sql: string): string => {
+  let output = "";
+  let index = 0;
+  while (index < sql.length) {
+    const char = sql[index];
+    const next = sql[index + 1];
+    if (char === "-" && next === "-") {
+      while (index < sql.length && sql[index] !== "\n") index += 1;
+      output += "\n";
+    } else if (char === "/" && next === "*") {
+      index += 2;
+      while (index < sql.length && !(sql[index] === "*" && sql[index + 1] === "/")) index += 1;
+      index += 2;
+      output += " ";
+    } else if (char === "'" || char === '"' || char === "`") {
+      const quote = char;
+      output += " ";
+      index += 1;
+      while (index < sql.length) {
+        if (sql[index] === quote && sql[index + 1] === quote) {
+          index += 2;
+        } else if (sql[index] === quote) {
+          index += 1;
+          break;
+        } else {
+          index += 1;
+        }
+      }
+    } else {
+      output += char;
+      index += 1;
+    }
+  }
+  return output;
+};
+
+export const validateReadOnlySql = (input: string): string => {
+  const trimmed = input.trim();
+  if (!trimmed) throw new QueryRejectedError("SQL query is empty.");
+  const scrubbed = scrubSql(trimmed);
+  const withoutTrailingSemicolon = trimmed.endsWith(";") ? trimmed.slice(0, -1).trimEnd() : trimmed;
+  const scrubbedWithoutTrailingSemicolon = scrubbed.endsWith(";") ? scrubbed.slice(0, -1) : scrubbed;
+  if (scrubbedWithoutTrailingSemicolon.includes(";")) {
+    throw new QueryRejectedError("Only one SQL statement is allowed.");
+  }
+  if (!/^\s*(SELECT|WITH)\b/i.test(scrubbedWithoutTrailingSemicolon)) {
+    throw new QueryRejectedError("Only SELECT or WITH...SELECT queries are allowed.");
+  }
+  if (PROHIBITED_KEYWORDS.test(scrubbedWithoutTrailingSemicolon)) {
+    throw new QueryRejectedError("The query contains a statement that can change state.");
+  }
+  return withoutTrailingSemicolon;
+};
+
+export interface QueryColumn {
+  name: string;
+  type: string;
+  geometryRole?: "geojson";
+}
+
+export interface QueryResult {
+  status: "success" | "empty";
+  columns: QueryColumn[];
+  rows: Record<string, unknown>[];
+  rowCount: number;
+  truncated: boolean;
+}
+
+interface QueryConnection {
+  send(
+    sql: string,
+    allowStreamResult?: boolean
+  ): Promise<{
+    schema?: { fields: Array<{ name: string; type: { toString(): string } }> };
+    open(): Promise<unknown>;
+    [Symbol.asyncIterator](): AsyncIterator<{
+      schema: { fields: Array<{ name: string; type: { toString(): string } }> };
+      toArray(): Array<{ toJSON(): Record<string, unknown> }>;
+    }>;
+  }>;
+  cancelSent(): Promise<boolean>;
+  close(): Promise<void>;
+}
+
+interface QueryDatabase {
+  connect(): Promise<QueryConnection>;
+  terminate(): Promise<unknown>;
+}
+
+const jsonSafe = (value: unknown): unknown => {
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Uint8Array) return `[binary ${value.byteLength} bytes]`;
+  if (Array.isArray(value)) return value.map(jsonSafe);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, jsonSafe(entry)]));
+  }
+  return value;
+};
+
+export class QueryRuntime {
+  private epoch = 0;
+  private disposed = false;
+  private active?: { connection: QueryConnection; epoch: number };
+  private readonly database: QueryDatabase;
+  private readonly cleanupAdmin: () => Promise<void>;
+  private readonly synchronize?: (snapshot: QuerySnapshot) => Promise<void>;
+
+  constructor(
+    database: QueryDatabase,
+    cleanupAdmin: () => Promise<void> = async () => undefined,
+    synchronize?: (snapshot: QuerySnapshot) => Promise<void>
+  ) {
+    this.database = database;
+    this.cleanupAdmin = cleanupAdmin;
+    this.synchronize = synchronize;
+  }
+
+  async execute(sql: string): Promise<QueryResult | null> {
+    if (this.disposed) throw new Error("Query runtime is disposed.");
+    const normalized = validateReadOnlySql(sql);
+    const epoch = ++this.epoch;
+    const connection = await this.database.connect();
+    if (this.disposed || epoch !== this.epoch) {
+      await connection.close().catch(() => undefined);
+      return null;
+    }
+    this.active = { connection, epoch };
+    try {
+      const stream = await connection.send(
+        `SELECT * FROM (${normalized}) AS user_result LIMIT ${QUERY_ROW_LIMIT + 1}`,
+        true
+      );
+      await stream.open();
+      const rows: Record<string, unknown>[] = [];
+      let schema = stream.schema;
+      for await (const batch of stream) {
+        schema ??= batch.schema;
+        for (const row of batch.toArray()) {
+          if (rows.length > QUERY_ROW_LIMIT) break;
+          rows.push(jsonSafe(row.toJSON()) as Record<string, unknown>);
+        }
+        if (rows.length > QUERY_ROW_LIMIT) break;
+      }
+      if (this.disposed || epoch !== this.epoch) return null;
+      if (!schema) throw new Error("DuckDB query result did not provide a schema.");
+      const columns = schema.fields.map((field) => ({
+        name: field.name,
+        type: field.type.toString(),
+        ...(field.name === "geometry_geojson" ? { geometryRole: "geojson" as const } : {}),
+      }));
+      const truncated = rows.length > QUERY_ROW_LIMIT;
+      if (truncated) rows.length = QUERY_ROW_LIMIT;
+      return {
+        status: rows.length === 0 ? "empty" : "success",
+        columns,
+        rows,
+        rowCount: rows.length,
+        truncated,
+      };
+    } catch (error) {
+      if (this.disposed || epoch !== this.epoch) return null;
+      throw error;
+    } finally {
+      if (this.active?.epoch === epoch) this.active = undefined;
+      await connection.close().catch(() => undefined);
+    }
+  }
+
+  async cancel(): Promise<void> {
+    this.epoch += 1;
+    const active = this.active;
+    this.active = undefined;
+    if (active) await active.connection.cancelSent().catch(() => false);
+  }
+
+  async refresh(snapshot: QuerySnapshot): Promise<void> {
+    if (!this.synchronize) throw new Error("Query snapshot refresh is unavailable.");
+    await this.cancel();
+    await this.synchronize(snapshot);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    await this.cancel();
+    await this.cleanupAdmin().catch(() => undefined);
+    await this.database.terminate().catch(() => undefined);
+  }
+}
+
+export const createQueryRuntime = async (snapshot: QuerySnapshot): Promise<QueryRuntime> => {
+  const worker = new Worker(bundle.mainWorker!, { type: "module" });
+  const database = new duckdb.AsyncDuckDB(new duckdb.ConsoleLogger(), worker);
+  let admin: duckdb.AsyncDuckDBConnection | undefined;
+  try {
+    await database.instantiate(bundle.mainModule, bundle.pthreadWorker);
+    admin = await database.connect();
+    try {
+      await admin.query("INSTALL spatial;");
+      await admin.query("LOAD spatial;");
+    } catch (error) {
+      console.warn("Spatial extension load failed in query sandbox:", error);
+    }
+    await initializeQueryViews(admin, snapshot);
+    await admin.query("SET enable_external_access = false;");
+    await admin.query("SET lock_configuration = true;");
+    const ownedAdmin = admin;
+    return new QueryRuntime(
+      database,
+      () => ownedAdmin.close(),
+      (nextSnapshot) => initializeQueryViews(ownedAdmin, nextSnapshot)
+    );
+  } catch (error) {
+    await admin?.close().catch(() => undefined);
+    await database.terminate().catch(() => undefined);
+    throw error;
+  }
+};

--- a/src/db/queryViews.test.ts
+++ b/src/db/queryViews.test.ts
@@ -1,0 +1,171 @@
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
+import { describe, expect, it, vi } from "vitest";
+import type { Layer } from "../domain/geometryFeature";
+import { QUERY_FEATURES_VIEW, QUERY_LAYERS_VIEW, initializeQueryViews, type QuerySnapshot } from "./queryViews";
+import { mapJsonFeatureRow, mapSpatialFeatureRow } from "./geometryRepository";
+
+const emptyResult = () => ({ toArray: () => [] });
+
+const snapshot: QuerySnapshot = {
+  features: [
+    {
+      id: "line-1",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [0, 1],
+          [2, 3],
+        ],
+      },
+      properties: { category: "road" },
+      style: { strokeColor: "#112233", strokeWidth: 2 },
+      layerId: "layer-1",
+      createdAt: "2026-07-24T00:00:00.000Z",
+    },
+    {
+      id: "polygon-1",
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+        ],
+      },
+      properties: { category: "parcel" },
+      style: { strokeColor: "#445566", strokeWidth: 3, fillColor: "#abcdef", fillOpacity: 0.4 },
+      layerId: "layer-1",
+      createdAt: "2026-07-24T00:01:00.000Z",
+    },
+  ],
+  layers: [
+    {
+      id: "layer-1",
+      name: "Imported",
+      visible: true,
+      order: 4,
+      createdAt: "2026-07-23T00:00:00.000Z",
+    },
+  ],
+};
+
+const createConnection = () => {
+  const prepared = new Map<string, ReturnType<typeof vi.fn>>();
+  const query = vi.fn().mockResolvedValue(emptyResult());
+  const prepare = vi.fn(async (sql: string) => {
+    const execute = vi.fn().mockResolvedValue(emptyResult());
+    prepared.set(sql, execute);
+    return { query: execute, close: vi.fn() };
+  });
+  return {
+    connection: { query, prepare } as unknown as AsyncDuckDBConnection,
+    prepare,
+    prepared,
+    query,
+  };
+};
+
+describe("query views", () => {
+  it("canonical featureとlayerをdocumented viewへtransactionalに同期する", async () => {
+    const fixture = createConnection();
+
+    await initializeQueryViews(fixture.connection, snapshot);
+
+    const sql = fixture.query.mock.calls.map(([statement]) => String(statement));
+    expect(sql[0]).toBe("BEGIN TRANSACTION;");
+    expect(sql.at(-1)).toBe("COMMIT;");
+    expect(sql.some((statement) => statement.includes(`CREATE OR REPLACE VIEW ${QUERY_FEATURES_VIEW}`))).toBe(true);
+    expect(sql.some((statement) => statement.includes(`CREATE OR REPLACE VIEW ${QUERY_LAYERS_VIEW}`))).toBe(true);
+
+    const layerInsert = [...fixture.prepared.entries()].find(([statement]) =>
+      statement.includes("INSERT INTO query_snapshot_layers")
+    )?.[1];
+    expect(layerInsert).toHaveBeenCalledWith("layer-1", "Imported", true, 4, "2026-07-23T00:00:00.000Z");
+
+    const featureInsert = [...fixture.prepared.entries()].find(([statement]) =>
+      statement.includes("INSERT INTO query_snapshot_features")
+    )?.[1];
+    expect(featureInsert).toHaveBeenNthCalledWith(
+      1,
+      "line-1",
+      "LineString",
+      '{"type":"LineString","coordinates":[[0,1],[2,3]]}',
+      '{"category":"road"}',
+      '{"strokeColor":"#112233","strokeWidth":2}',
+      "layer-1",
+      "2026-07-24T00:00:00.000Z",
+      1
+    );
+    expect(featureInsert).toHaveBeenNthCalledWith(
+      2,
+      "polygon-1",
+      "Polygon",
+      '{"type":"Polygon","coordinates":[[[0,0],[2,0],[2,2],[0,0]]]}',
+      '{"category":"parcel"}',
+      '{"strokeColor":"#445566","strokeWidth":3,"fillColor":"#abcdef","fillOpacity":0.4}',
+      "layer-1",
+      "2026-07-24T00:01:00.000Z",
+      2
+    );
+  });
+
+  it("Spatial/JSON repository rowsから同じcanonical view valuesを作る", async () => {
+    const spatialFixture = createConnection();
+    const jsonFixture = createConnection();
+    const style = '{"strokeColor":"#112233","strokeWidth":2}';
+    const properties = '{"category":"road"}';
+    const spatialFeature = mapSpatialFeatureRow({
+      id: "line-1",
+      geometry: '{"type":"LineString","coordinates":[[0,1],[2,3]]}',
+      properties,
+      style,
+      layer_id: "layer-1",
+      created_at: "2026-07-24T00:00:00.000Z",
+    });
+    const jsonFeature = mapJsonFeatureRow({
+      id: "line-1",
+      geom_type: "LineString",
+      coordinates: "[[0,1],[2,3]]",
+      properties,
+      style,
+      layer_id: "layer-1",
+      created_at: "2026-07-24T00:00:00.000Z",
+    });
+    const layers: Layer[] = snapshot.layers.map((layer) => ({ ...layer }));
+
+    await initializeQueryViews(spatialFixture.connection, { features: [spatialFeature], layers });
+    await initializeQueryViews(jsonFixture.connection, { features: [jsonFeature], layers });
+
+    const featureCalls = (fixture: ReturnType<typeof createConnection>) =>
+      [...fixture.prepared.entries()].find(([statement]) =>
+        statement.includes("INSERT INTO query_snapshot_features")
+      )?.[1].mock.calls;
+    expect(featureCalls(spatialFixture)).toEqual(featureCalls(jsonFixture));
+
+    const viewSql = spatialFixture.query.mock.calls
+      .map(([statement]) => String(statement))
+      .filter((statement) => statement.includes("CREATE OR REPLACE VIEW"));
+    expect(viewSql).toEqual([
+      expect.stringContaining(
+        "id, geometry_type, geometry_geojson, properties, style, layer_id, created_at, feature_order"
+      ),
+      expect.stringContaining("id, name, visible, layer_order, created_at"),
+    ]);
+  });
+
+  it("snapshot同期失敗時はrollbackしてcommitしない", async () => {
+    const fixture = createConnection();
+    fixture.prepare.mockImplementation(async (sql: string) => ({
+      query: vi.fn(async () => {
+        if (sql.includes("INSERT INTO query_snapshot_features")) throw new Error("snapshot insert failed");
+        return emptyResult();
+      }),
+      close: vi.fn(),
+    }));
+
+    await expect(initializeQueryViews(fixture.connection, snapshot)).rejects.toThrow("snapshot insert failed");
+
+    expect(fixture.query).toHaveBeenCalledWith("ROLLBACK;");
+    expect(fixture.query).not.toHaveBeenCalledWith("COMMIT;");
+  });
+});

--- a/src/db/queryViews.ts
+++ b/src/db/queryViews.ts
@@ -1,0 +1,115 @@
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
+import type { FeatureGeometry, GeometryFeature, Layer, Point2D } from "../domain/geometryFeature";
+
+export const QUERY_FEATURES_VIEW = "geometry_features";
+export const QUERY_LAYERS_VIEW = "geometry_layers";
+
+export interface QuerySnapshot {
+  features: GeometryFeature[];
+  layers: Layer[];
+}
+
+const closePolygon = (coordinates: Point2D[]): Point2D[] => [
+  ...coordinates.map(([x, y]) => [x, y] as Point2D),
+  [...coordinates[0]] as Point2D,
+];
+
+const geometryGeoJson = (geometry: FeatureGeometry): string =>
+  JSON.stringify(
+    geometry.type === "Polygon"
+      ? { type: geometry.type, coordinates: [closePolygon(geometry.coordinates)] }
+      : { type: geometry.type, coordinates: geometry.coordinates }
+  );
+
+export const initializeQueryViews = async (
+  connection: AsyncDuckDBConnection,
+  { features, layers }: QuerySnapshot
+): Promise<void> => {
+  await connection.query("BEGIN TRANSACTION;");
+  try {
+    await connection.query(`
+      CREATE TABLE IF NOT EXISTS query_snapshot_features (
+        id VARCHAR NOT NULL,
+        geometry_type VARCHAR NOT NULL,
+        geometry_geojson VARCHAR NOT NULL,
+        properties JSON NOT NULL,
+        style JSON NOT NULL,
+        layer_id VARCHAR NOT NULL,
+        created_at TIMESTAMP NOT NULL,
+        feature_order BIGINT NOT NULL
+      );
+    `);
+    await connection.query(`
+      CREATE TABLE IF NOT EXISTS query_snapshot_layers (
+        id VARCHAR NOT NULL,
+        name VARCHAR NOT NULL,
+        visible BOOLEAN NOT NULL,
+        layer_order INTEGER NOT NULL,
+        created_at TIMESTAMP NOT NULL
+      );
+    `);
+    await connection.query("DELETE FROM query_snapshot_features;");
+    await connection.query("DELETE FROM query_snapshot_layers;");
+
+    const layerStatement = await connection.prepare(`
+      INSERT INTO query_snapshot_layers(id, name, visible, layer_order, created_at)
+      VALUES (?, ?, ?, ?, CAST(? AS TIMESTAMP));
+    `);
+    try {
+      for (const layer of layers) {
+        await layerStatement.query(layer.id, layer.name, layer.visible, layer.order, layer.createdAt);
+      }
+    } finally {
+      await layerStatement.close();
+    }
+
+    const featureStatement = await connection.prepare(`
+      INSERT INTO query_snapshot_features(
+        id,
+        geometry_type,
+        geometry_geojson,
+        properties,
+        style,
+        layer_id,
+        created_at,
+        feature_order
+      )
+      VALUES (?, ?, ?, CAST(? AS JSON), CAST(? AS JSON), ?, CAST(? AS TIMESTAMP), ?);
+    `);
+    try {
+      for (const [index, feature] of features.entries()) {
+        await featureStatement.query(
+          feature.id,
+          feature.geometry.type,
+          geometryGeoJson(feature.geometry),
+          JSON.stringify(feature.properties),
+          JSON.stringify(feature.style),
+          feature.layerId,
+          feature.createdAt,
+          index + 1
+        );
+      }
+    } finally {
+      await featureStatement.close();
+    }
+
+    await connection.query(`
+      CREATE OR REPLACE VIEW ${QUERY_FEATURES_VIEW} AS
+      SELECT id, geometry_type, geometry_geojson, properties, style, layer_id, created_at, feature_order
+      FROM query_snapshot_features;
+    `);
+    await connection.query(`
+      CREATE OR REPLACE VIEW ${QUERY_LAYERS_VIEW} AS
+      SELECT id, name, visible, layer_order, created_at
+      FROM query_snapshot_layers;
+    `);
+    await connection.query("COMMIT;");
+  } catch (error) {
+    try {
+      await connection.query("ROLLBACK;");
+    } catch {
+      // Preserve the snapshot synchronization failure; rollback is best-effort.
+    }
+    throw error;
+  }
+};

--- a/src/hooks/useGeometryFeatures.ts
+++ b/src/hooks/useGeometryFeatures.ts
@@ -13,6 +13,9 @@ import { simplifyFeatureGeometry, toRenderableStroke } from "../domain/renderabl
 import { loadExportFeatureCollection } from "../lib/exportGeometryFeatures";
 import { importGeometryFeaturesWithContext } from "../lib/importGeometryFeatures";
 import { createPromiseQueue } from "../lib/promiseQueue";
+import type { QueryResult } from "../db/queryRuntime";
+import { queryResultFeatures } from "../lib/queryResultGeometry";
+import { createId } from "../lib/id";
 
 export type GeometryType = "line" | "polygon";
 
@@ -23,6 +26,10 @@ export interface StorageStatus {
   migrationWarning?: string;
   error?: string;
 }
+
+export type QueryPromotionResult =
+  | { status: "saved"; count: number; layerName: string }
+  | { status: "invalid-name" | "empty" | "failed" };
 
 const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
 
@@ -165,6 +172,27 @@ export function useGeometryFeatures(strokeColor: string, strokeWidth: number, si
     [runRepositoryAction, simplifyOn, strokeColor, strokeWidth]
   );
 
+  const promoteQueryResult = useCallback(
+    async (result: QueryResult, requestedLayerName: string): Promise<QueryPromotionResult> => {
+      const layerName = requestedLayerName.trim();
+      if (!layerName) return { status: "invalid-name" };
+      const layerId = createId();
+      const promotedFeatures = queryResultFeatures(result, layerId);
+      if (promotedFeatures.length === 0) return { status: "empty" };
+      const layer: Layer = {
+        id: layerId,
+        name: layerName,
+        visible: true,
+        order: layers.reduce((highest, candidate) => Math.max(highest, candidate.order), -1) + 1,
+        createdAt: new Date().toISOString(),
+      };
+      const saved = await runRepositoryAction((repository) => repository.importGeoJSON([layer], promotedFeatures));
+      if (!saved) return { status: "failed" };
+      return { status: "saved", count: promotedFeatures.length, layerName };
+    },
+    [layers, runRepositoryAction]
+  );
+
   const updateStroke = useCallback(
     async (id: string, points: Point2D[]) => {
       const feature = features.find((candidate) => candidate.id === id);
@@ -249,6 +277,7 @@ export function useGeometryFeatures(strokeColor: string, strokeWidth: number, si
     storageStatus,
     strokes,
     persistStroke,
+    promoteQueryResult,
     updateStroke,
     handleUndo,
     handleClear,

--- a/src/hooks/useQueryWorkbench.ts
+++ b/src/hooks/useQueryWorkbench.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createQueryRuntime, type QueryResult, type QueryRuntime } from "../db/queryRuntime";
+import type { GeometryFeature, Layer } from "../domain/geometryFeature";
+
+export type QueryUiStatus = "initializing" | "ready" | "running" | "cancelled" | "empty" | "success" | "error";
+
+export const SQL_EXAMPLES = [
+  { label: "Filter features", sql: "SELECT id, geometry_type, layer_id FROM geometry_features ORDER BY feature_order" },
+  {
+    label: "Measure geometry",
+    sql: "SELECT id, ST_Length(ST_GeomFromGeoJSON(geometry_geojson)) AS length FROM geometry_features",
+  },
+  {
+    label: "Convert geometry",
+    sql: "SELECT id, ST_AsText(ST_GeomFromGeoJSON(geometry_geojson)) AS geometry_wkt FROM geometry_features",
+  },
+] as const;
+
+export function useQueryWorkbench(features: GeometryFeature[], layers: Layer[], storageLoading: boolean) {
+  const runtimeRef = useRef<QueryRuntime | null>(null);
+  const requestRef = useRef(0);
+  const queueRef = useRef(Promise.resolve());
+  const [sql, setSql] = useState<string>(SQL_EXAMPLES[0].sql);
+  const [history, setHistory] = useState<string[]>([]);
+  const [status, setStatus] = useState<QueryUiStatus>("initializing");
+  const [result, setResult] = useState<QueryResult | null>(null);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (storageLoading) return;
+    const snapshot = { features, layers };
+    queueRef.current = queueRef.current.then(async () => {
+      try {
+        if (runtimeRef.current) await runtimeRef.current.refresh(snapshot);
+        else runtimeRef.current = await createQueryRuntime(snapshot);
+        setStatus("ready");
+        setError(undefined);
+      } catch (cause) {
+        setStatus("error");
+        setError(cause instanceof Error ? cause.message : String(cause));
+      }
+    });
+  }, [features, layers, storageLoading]);
+
+  useEffect(
+    () => () => {
+      requestRef.current += 1;
+      void runtimeRef.current?.dispose();
+      runtimeRef.current = null;
+    },
+    []
+  );
+
+  const execute = useCallback(async () => {
+    const runtime = runtimeRef.current;
+    if (!runtime) return;
+    const request = ++requestRef.current;
+    setStatus("running");
+    setError(undefined);
+    setHistory((current) => [sql, ...current.filter((entry) => entry !== sql)].slice(0, 10));
+    try {
+      const next = await runtime.execute(sql);
+      if (request !== requestRef.current || !next) return;
+      setResult(next);
+      setStatus(next.status);
+    } catch (cause) {
+      if (request !== requestRef.current) return;
+      setResult(null);
+      setStatus("error");
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  }, [sql]);
+
+  const cancel = useCallback(async () => {
+    requestRef.current += 1;
+    await runtimeRef.current?.cancel();
+    setStatus("cancelled");
+  }, []);
+
+  return { cancel, error, execute, history, result, setSql, sql, status };
+}

--- a/src/hooks/useQueryWorkbench.ts
+++ b/src/hooks/useQueryWorkbench.ts
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createQueryRuntime, type QueryResult, type QueryRuntime } from "../db/queryRuntime";
 import type { GeometryFeature, Layer } from "../domain/geometryFeature";
+import type { RenderableStroke } from "../domain/renderableStroke";
+import { queryResultStrokes } from "../lib/queryResultGeometry";
 
 export type QueryUiStatus = "initializing" | "ready" | "running" | "cancelled" | "empty" | "success" | "error";
 
 export const SQL_EXAMPLES = [
-  { label: "Filter features", sql: "SELECT id, geometry_type, layer_id FROM geometry_features ORDER BY feature_order" },
+  {
+    label: "Filter features",
+    sql: "SELECT id, geometry_type, geometry_geojson, layer_id FROM geometry_features ORDER BY feature_order",
+  },
   {
     label: "Measure geometry",
     sql: "SELECT id, ST_Length(ST_GeomFromGeoJSON(geometry_geojson)) AS length FROM geometry_features",
@@ -24,10 +29,12 @@ export function useQueryWorkbench(features: GeometryFeature[], layers: Layer[], 
   const [history, setHistory] = useState<string[]>([]);
   const [status, setStatus] = useState<QueryUiStatus>("initializing");
   const [result, setResult] = useState<QueryResult | null>(null);
+  const [temporaryStrokes, setTemporaryStrokes] = useState<RenderableStroke[]>([]);
   const [error, setError] = useState<string>();
 
   useEffect(() => {
     if (storageLoading) return;
+    setTemporaryStrokes([]);
     const snapshot = { features, layers };
     queueRef.current = queueRef.current.then(async () => {
       try {
@@ -56,12 +63,14 @@ export function useQueryWorkbench(features: GeometryFeature[], layers: Layer[], 
     if (!runtime) return;
     const request = ++requestRef.current;
     setStatus("running");
+    setTemporaryStrokes([]);
     setError(undefined);
     setHistory((current) => [sql, ...current.filter((entry) => entry !== sql)].slice(0, 10));
     try {
       const next = await runtime.execute(sql);
       if (request !== requestRef.current || !next) return;
       setResult(next);
+      setTemporaryStrokes(queryResultStrokes(next));
       setStatus(next.status);
     } catch (cause) {
       if (request !== requestRef.current) return;
@@ -74,8 +83,9 @@ export function useQueryWorkbench(features: GeometryFeature[], layers: Layer[], 
   const cancel = useCallback(async () => {
     requestRef.current += 1;
     await runtimeRef.current?.cancel();
+    setTemporaryStrokes([]);
     setStatus("cancelled");
   }, []);
 
-  return { cancel, error, execute, history, result, setSql, sql, status };
+  return { cancel, error, execute, history, result, setSql, sql, status, temporaryStrokes };
 }

--- a/src/hooks/useQueryWorkbench.ts
+++ b/src/hooks/useQueryWorkbench.ts
@@ -59,14 +59,16 @@ export function useQueryWorkbench(features: GeometryFeature[], layers: Layer[], 
   );
 
   const execute = useCallback(async () => {
-    const runtime = runtimeRef.current;
-    if (!runtime) return;
     const request = ++requestRef.current;
     setStatus("running");
     setTemporaryStrokes([]);
     setError(undefined);
     setHistory((current) => [sql, ...current.filter((entry) => entry !== sql)].slice(0, 10));
     try {
+      await queueRef.current;
+      if (request !== requestRef.current) return;
+      const runtime = runtimeRef.current;
+      if (!runtime) throw new Error("Query runtime is unavailable.");
       const next = await runtime.execute(sql);
       if (request !== requestRef.current || !next) return;
       setResult(next);

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,7 @@ main {
 } /* ←これ重要。子の%高さでの増殖を防ぐ */
 
 button,
+input,
 select,
 textarea {
   font: inherit;
@@ -70,6 +71,7 @@ textarea {
 }
 
 .sql-workbench textarea,
+.sql-workbench input,
 .sql-workbench select {
   width: 100%;
   border: 1px solid #cbd5e1;
@@ -87,6 +89,10 @@ textarea {
 }
 
 .sql-workbench select {
+  padding: 8px;
+}
+
+.sql-workbench input {
   padding: 8px;
 }
 
@@ -127,6 +133,29 @@ textarea {
 .query-message--error {
   color: #991b1b;
   background: #fee2e2;
+}
+
+.query-promotion {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #dbe2ea;
+}
+
+.query-promotion .query-message,
+.query-promotion .sql-label {
+  margin: 0;
+}
+
+.query-promotion button {
+  justify-self: start;
+  padding: 7px 12px;
+}
+
+.query-promotion small {
+  color: #536176;
+  line-height: 1.4;
 }
 
 .query-results {

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,163 @@ main {
   min-height: 0;
 } /* ←これ重要。子の%高さでの増殖を防ぐ */
 
+button,
+select,
+textarea {
+  font: inherit;
+}
+
+.workbench-layout {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 410px;
+}
+
+.sql-workbench {
+  min-width: 0;
+  overflow: auto;
+  padding: 18px;
+  border-left: 1px solid #dbe2ea;
+  background: #f8fafc;
+  color: #172033;
+}
+
+.sql-workbench__heading,
+.query-results__meta,
+.sql-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.sql-workbench h2 {
+  margin: 2px 0 16px;
+  font-size: 20px;
+}
+
+.sql-workbench__eyebrow,
+.sql-label,
+.query-status,
+.query-results__meta {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.sql-label {
+  display: block;
+  margin: 12px 0 6px;
+  color: #536176;
+}
+
+.sql-workbench textarea,
+.sql-workbench select {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
+  background: white;
+}
+
+.sql-workbench textarea {
+  min-height: 132px;
+  resize: vertical;
+  padding: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.sql-workbench select {
+  padding: 8px;
+}
+
+.sql-actions {
+  justify-content: flex-start;
+  margin-top: 8px;
+}
+
+.sql-actions button {
+  padding: 7px 12px;
+}
+
+.query-status {
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: #e2e8f0;
+}
+
+.query-status--success,
+.query-status--ready {
+  color: #166534;
+  background: #dcfce7;
+}
+
+.query-status--error {
+  color: #991b1b;
+  background: #fee2e2;
+}
+
+.query-message {
+  margin-top: 12px;
+  padding: 9px;
+  border-radius: 7px;
+  background: #e2e8f0;
+  font-size: 12px;
+}
+
+.query-message--error {
+  color: #991b1b;
+  background: #fee2e2;
+}
+
+.query-results {
+  margin-top: 14px;
+  border-top: 1px solid #dbe2ea;
+  padding-top: 12px;
+}
+
+.query-results__meta {
+  margin-bottom: 8px;
+  color: #536176;
+}
+
+.query-table-wrap {
+  overflow: auto;
+  max-height: 320px;
+  border: 1px solid #dbe2ea;
+  border-radius: 7px;
+  background: white;
+}
+
+.query-table-wrap table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  text-align: left;
+}
+
+.query-table-wrap th,
+.query-table-wrap td {
+  padding: 7px 9px;
+  border-bottom: 1px solid #edf2f7;
+  white-space: nowrap;
+}
+
+.query-table-wrap th {
+  position: sticky;
+  top: 0;
+  background: #eef2f7;
+}
+
+.query-table-wrap th small {
+  display: block;
+  color: #718096;
+  font-weight: 400;
+}
+
 .workspace-warning-overlay {
   position: absolute;
   inset: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -168,6 +168,14 @@ textarea {
   background: #eef2f7;
 }
 
+.query-table-wrap tr[data-query-geometry="rendered"] td {
+  background: #fdf2f8;
+}
+
+.query-table-wrap tr[data-query-geometry="rendered"] td:first-child {
+  box-shadow: inset 3px 0 #ec4899;
+}
+
 .query-table-wrap th small {
   display: block;
   color: #718096;

--- a/src/lib/queryResultGeometry.test.ts
+++ b/src/lib/queryResultGeometry.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { QueryResult } from "../db/queryRuntime";
+import { queryResultStrokes } from "./queryResultGeometry";
+
+const result = (values: unknown[]): QueryResult => ({
+  status: "success",
+  columns: [{ name: "geometry_geojson", type: "VARCHAR", geometryRole: "geojson" }],
+  rows: values.map((value) => ({ geometry_geojson: value })),
+  rowCount: values.length,
+  truncated: false,
+});
+
+describe("query result geometry", () => {
+  it("LineStringとclosed Polygonをtemporary strokesへ変換する", () => {
+    const strokes = queryResultStrokes(
+      result([
+        '{"type":"LineString","coordinates":[[0,0],[2,2]]}',
+        '{"type":"Polygon","coordinates":[[[0,0],[2,0],[2,2],[0,0]]]}',
+      ])
+    );
+    expect(strokes.map(({ geomType, ptsPx }) => ({ geomType, ptsPx }))).toEqual([
+      {
+        geomType: "line",
+        ptsPx: [
+          [0, 0],
+          [2, 2],
+        ],
+      },
+      {
+        geomType: "polygon",
+        ptsPx: [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+        ],
+      },
+    ]);
+  });
+
+  it("NULL、invalid、unsupported geometryをskipしrows自体は変更しない", () => {
+    const queryResult = result([null, "not-json", '{"type":"Point","coordinates":[1,2]}']);
+    expect(queryResultStrokes(queryResult)).toEqual([]);
+    expect(queryResult.rows).toHaveLength(3);
+  });
+
+  it("geometry role列がなければ描画しない", () => {
+    expect(queryResultStrokes({ ...result([]), columns: [{ name: "id", type: "VARCHAR" }] })).toEqual([]);
+  });
+});

--- a/src/lib/queryResultGeometry.test.ts
+++ b/src/lib/queryResultGeometry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { QueryResult } from "../db/queryRuntime";
-import { queryResultStrokes } from "./queryResultGeometry";
+import { queryResultFeatures, queryResultStrokes } from "./queryResultGeometry";
 
 const result = (values: unknown[]): QueryResult => ({
   status: "success",
@@ -45,5 +45,40 @@ describe("query result geometry", () => {
 
   it("geometry role列がなければ描画しない", () => {
     expect(queryResultStrokes({ ...result([]), columns: [{ name: "id", type: "VARCHAR" }] })).toEqual([]);
+  });
+
+  it("promotion用featureへrow attributes、style、layer membershipを保持しfresh IDsを割り当てる", () => {
+    const queryResult: QueryResult = {
+      ...result(['{"type":"LineString","coordinates":[[0,0],[2,2]]}']),
+      columns: [
+        { name: "geometry_geojson", type: "VARCHAR", geometryRole: "geojson" },
+        { name: "category", type: "VARCHAR" },
+        { name: "score", type: "INTEGER" },
+      ],
+      rows: [
+        {
+          geometry_geojson: '{"type":"LineString","coordinates":[[0,0],[2,2]]}',
+          category: "road",
+          score: 7,
+        },
+      ],
+    };
+
+    const first = queryResultFeatures(queryResult, "analysis-layer")[0];
+    const second = queryResultFeatures(queryResult, "analysis-layer")[0];
+
+    expect(first).toMatchObject({
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [0, 0],
+          [2, 2],
+        ],
+      },
+      properties: { category: "road", score: 7 },
+      style: { strokeColor: "#ec4899", strokeWidth: 5, fillColor: "#f9a8d4", fillOpacity: 0.18 },
+      layerId: "analysis-layer",
+    });
+    expect(first.id).not.toBe(second.id);
   });
 });

--- a/src/lib/queryResultGeometry.ts
+++ b/src/lib/queryResultGeometry.ts
@@ -1,0 +1,50 @@
+import type { QueryResult } from "../db/queryRuntime";
+import {
+  createGeometryFeature,
+  isFeatureGeometry,
+  type FeatureGeometry,
+  type Point2D,
+} from "../domain/geometryFeature";
+import { toRenderableStroke, type RenderableStroke } from "../domain/renderableStroke";
+
+const parseGeometry = (value: unknown): FeatureGeometry | null => {
+  if (typeof value !== "string") return null;
+  try {
+    const parsed = JSON.parse(value) as { type?: unknown; coordinates?: unknown };
+    if (parsed.type !== "LineString" && parsed.type !== "Polygon") return null;
+    const coordinates =
+      parsed.type === "Polygon" && Array.isArray(parsed.coordinates) ? parsed.coordinates[0] : parsed.coordinates;
+    if (!Array.isArray(coordinates)) return null;
+    const open = coordinates.map((point) => point as Point2D);
+    if (
+      parsed.type === "Polygon" &&
+      open.length > 1 &&
+      open[0][0] === open.at(-1)?.[0] &&
+      open[0][1] === open.at(-1)?.[1]
+    )
+      open.pop();
+    const geometry = { type: parsed.type, coordinates: open } as FeatureGeometry;
+    return isFeatureGeometry(geometry) ? geometry : null;
+  } catch {
+    return null;
+  }
+};
+
+export const queryResultStrokes = (result: QueryResult): RenderableStroke[] => {
+  const geometryColumn = result.columns.find((column) => column.geometryRole === "geojson");
+  if (!geometryColumn) return [];
+  return result.rows.flatMap((row, index) => {
+    const geometry = parseGeometry(row[geometryColumn.name]);
+    if (!geometry) return [];
+    return [
+      toRenderableStroke(
+        createGeometryFeature({
+          id: `query-result-${index}`,
+          geometry,
+          style: { strokeColor: "#ec4899", strokeWidth: 5, fillColor: "#f9a8d4", fillOpacity: 0.18 },
+          layerId: "__query_result__",
+        })
+      ),
+    ];
+  });
+};

--- a/src/lib/queryResultGeometry.ts
+++ b/src/lib/queryResultGeometry.ts
@@ -3,9 +3,18 @@ import {
   createGeometryFeature,
   isFeatureGeometry,
   type FeatureGeometry,
+  type GeometryFeature,
+  type JsonValue,
   type Point2D,
 } from "../domain/geometryFeature";
 import { toRenderableStroke, type RenderableStroke } from "../domain/renderableStroke";
+
+export const QUERY_RESULT_STYLE = {
+  strokeColor: "#ec4899",
+  strokeWidth: 5,
+  fillColor: "#f9a8d4",
+  fillOpacity: 0.18,
+} as const;
 
 const parseGeometry = (value: unknown): FeatureGeometry | null => {
   if (typeof value !== "string") return null;
@@ -30,21 +39,57 @@ const parseGeometry = (value: unknown): FeatureGeometry | null => {
   }
 };
 
-export const queryResultStrokes = (result: QueryResult): RenderableStroke[] => {
+const toJsonValue = (value: unknown): JsonValue => {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : String(value);
+  if (Array.isArray(value)) return value.map(toJsonValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, toJsonValue(entry)]));
+  }
+  return String(value);
+};
+
+export interface QueryResultGeometry {
+  rowIndex: number;
+  geometry: FeatureGeometry;
+  properties: Record<string, JsonValue>;
+}
+
+export const queryResultGeometries = (result: QueryResult): QueryResultGeometry[] => {
   const geometryColumn = result.columns.find((column) => column.geometryRole === "geojson");
   if (!geometryColumn) return [];
-  return result.rows.flatMap((row, index) => {
+  return result.rows.flatMap((row, rowIndex) => {
     const geometry = parseGeometry(row[geometryColumn.name]);
     if (!geometry) return [];
-    return [
-      toRenderableStroke(
-        createGeometryFeature({
-          id: `query-result-${index}`,
-          geometry,
-          style: { strokeColor: "#ec4899", strokeWidth: 5, fillColor: "#f9a8d4", fillOpacity: 0.18 },
-          layerId: "__query_result__",
-        })
-      ),
-    ];
+    const properties = Object.fromEntries(
+      result.columns
+        .filter((column) => column.name !== geometryColumn.name)
+        .map((column) => [column.name, toJsonValue(row[column.name])])
+    );
+    return [{ rowIndex, geometry, properties }];
   });
+};
+
+export const queryResultFeatures = (result: QueryResult, layerId: string): GeometryFeature[] =>
+  queryResultGeometries(result).map(({ geometry, properties }) =>
+    createGeometryFeature({
+      geometry,
+      properties,
+      style: QUERY_RESULT_STYLE,
+      layerId,
+    })
+  );
+
+export const queryResultStrokes = (result: QueryResult): RenderableStroke[] => {
+  return queryResultGeometries(result).map(({ rowIndex, geometry, properties }) =>
+    toRenderableStroke(
+      createGeometryFeature({
+        id: `query-result-${rowIndex}`,
+        geometry,
+        properties,
+        style: QUERY_RESULT_STYLE,
+        layerId: "__query_result__",
+      })
+    )
+  );
 };

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -233,4 +233,37 @@ test.describe("drawing workspace", () => {
     await page.getByRole("button", { name: "Measure" }).click();
     await expect(page.getByText(/Length: \d+\.\d px/)).toHaveCount(0);
   });
+
+  test("SQL workbenchでgeometryをqueryし履歴・empty・error・cancelを表示する", async ({ page }) => {
+    test.setTimeout(120_000);
+    await gotoApp(page);
+    const box = await getCanvasBox(page);
+    await page.getByRole("button", { name: "Clear" }).click();
+    await page.mouse.click(box.x + 100, box.y + 100);
+    await page.mouse.click(box.x + 240, box.y + 180);
+    await page.keyboard.press("Escape");
+
+    const run = page.getByRole("button", { name: "Run query" });
+    await expect(run).toBeEnabled({ timeout: 30_000 });
+    await run.click();
+    await expect(page.getByTestId("query-status")).toHaveText("success", { timeout: 30_000 });
+    await expect(page.getByRole("table")).toContainText("geometry_type");
+    await expect(page.getByRole("table")).toContainText("LineString");
+    await expect(page.getByText("1 rows")).toBeVisible();
+    await expect(page.getByText("Complete result")).toBeVisible();
+    await expect(page.locator("#sql-history option")).toHaveCount(2);
+
+    await page.getByTestId("sql-editor").fill("SELECT id FROM geometry_features WHERE false");
+    await run.click();
+    await expect(page.getByText("Query completed with no rows.")).toBeVisible();
+
+    await page.getByTestId("sql-editor").fill("SELECT broken");
+    await run.click();
+    await expect(page.getByRole("alert")).toBeVisible();
+
+    await page.getByTestId("sql-editor").fill("SELECT sum(i) FROM range(1000000000) values(i)");
+    await run.click();
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByText("Query cancelled.")).toBeVisible();
+  });
 });

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -305,12 +305,18 @@ test.describe("drawing workspace", () => {
     await page.mouse.click(box.x + 100, box.y + 100);
     await page.mouse.click(box.x + 240, box.y + 180);
     await page.keyboard.press("Escape");
+    const canvas = page.getByTestId("drawing-canvas");
+    const canvasBeforeQuery = await canvas.screenshot();
 
     const sql =
       "SELECT geometry_geojson, 'road' AS category, 7 AS score FROM geometry_features WHERE layer_id = 'default'";
     await page.getByTestId("sql-editor").fill(sql);
     await page.getByRole("button", { name: "Run query" }).click();
     await expect(page.getByTestId("temporary-result-count")).toHaveText("1 geometries rendered temporarily");
+    await expect(page.getByRole("table")).toContainText("road");
+    await expect(page.getByRole("table")).toContainText("7");
+    const canvasWithTemporaryResult = await canvas.screenshot();
+    expect(canvasWithTemporaryResult.equals(canvasBeforeQuery)).toBe(false);
     await expect(page.getByTestId("query-promotion-duplicate-policy")).toContainText(
       "creates a new layer with new feature IDs"
     );

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -234,7 +234,7 @@ test.describe("drawing workspace", () => {
     await expect(page.getByText(/Length: \d+\.\d px/)).toHaveCount(0);
   });
 
-  test("SQL workbenchでgeometryをqueryし履歴・empty・error・cancelを表示する", async ({ page }) => {
+  test("SQL result geometryを一時描画し永続化せず、query lifecycleを表示する", async ({ page }) => {
     test.setTimeout(120_000);
     await gotoApp(page);
     const box = await getCanvasBox(page);
@@ -251,19 +251,34 @@ test.describe("drawing workspace", () => {
     await expect(page.getByRole("table")).toContainText("LineString");
     await expect(page.getByText("1 rows")).toBeVisible();
     await expect(page.getByText("Complete result")).toBeVisible();
+    await expect(page.getByTestId("temporary-result-count")).toHaveText("1 geometries rendered temporarily");
+    await expect(page.locator('tr[data-query-geometry="rendered"]')).toHaveCount(1);
+    expect(await exportFeatureCount(page)).toBe(1);
     await expect(page.locator("#sql-history option")).toHaveCount(2);
 
+    await page.reload();
+    await expect(page.getByTestId("loading-overlay")).toBeHidden({ timeout: 30_000 });
+    await expect(page.getByTestId("temporary-result-count")).toHaveCount(0);
+    expect(await exportFeatureCount(page)).toBe(1);
+
+    await page.getByTestId("sql-editor").fill("SELECT id FROM geometry_features");
+    await page.getByRole("button", { name: "Run query" }).click();
+    await expect(page.getByTestId("query-status")).toHaveText("success");
+    await expect(page.getByTestId("temporary-result-count")).toHaveCount(0);
+
+    const runAfterReload = page.getByRole("button", { name: "Run query" });
     await page.getByTestId("sql-editor").fill("SELECT id FROM geometry_features WHERE false");
-    await run.click();
+    await runAfterReload.click();
     await expect(page.getByText("Query completed with no rows.")).toBeVisible();
 
     await page.getByTestId("sql-editor").fill("SELECT broken");
-    await run.click();
+    await runAfterReload.click();
     await expect(page.getByRole("alert")).toBeVisible();
 
     await page.getByTestId("sql-editor").fill("SELECT sum(i) FROM range(1000000000) values(i)");
-    await run.click();
+    await runAfterReload.click();
     await page.getByRole("button", { name: "Cancel" }).click();
     await expect(page.getByText("Query cancelled.")).toBeVisible();
+    await expect(page.getByTestId("temporary-result-count")).toHaveCount(0);
   });
 });

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -18,16 +18,31 @@ const getCanvasBox = async (page: Page) => {
   return box;
 };
 
-const exportFeatureCount = async (page: Page) => {
+interface ExportedFeatureCollection {
+  features: Array<{
+    id: string;
+    properties: Record<string, unknown>;
+    workbench: {
+      layerId: string;
+      style: { strokeColor: string; strokeWidth: number };
+    };
+  }>;
+  workbench: {
+    layers: Array<{ id: string; name: string }>;
+  };
+}
+
+const exportFeatures = async (page: Page): Promise<ExportedFeatureCollection> => {
   const downloadPromise = page.waitForEvent("download");
   await page.getByRole("button", { name: "Export GeoJSON" }).click();
   const download = await downloadPromise;
   const stream = await download.createReadStream();
   let text = "";
   for await (const chunk of stream) text += chunk.toString();
-  const collection = JSON.parse(text) as { features: unknown[] };
-  return collection.features.length;
+  return JSON.parse(text) as ExportedFeatureCollection;
 };
+
+const exportFeatureCount = async (page: Page) => (await exportFeatures(page)).features.length;
 
 test.describe("drawing workspace", () => {
   test.describe.configure({ mode: "serial" });
@@ -280,5 +295,61 @@ test.describe("drawing workspace", () => {
     await page.getByRole("button", { name: "Cancel" }).click();
     await expect(page.getByText("Query cancelled.")).toBeVisible();
     await expect(page.getByTestId("temporary-result-count")).toHaveCount(0);
+  });
+
+  test("query resultを名前付きlayerへ保存しattributesをreload後も保持する", async ({ page }) => {
+    test.setTimeout(150_000);
+    await gotoApp(page);
+    const box = await getCanvasBox(page);
+    await page.getByRole("button", { name: "Clear" }).click();
+    await page.mouse.click(box.x + 100, box.y + 100);
+    await page.mouse.click(box.x + 240, box.y + 180);
+    await page.keyboard.press("Escape");
+
+    const sql =
+      "SELECT geometry_geojson, 'road' AS category, 7 AS score FROM geometry_features WHERE layer_id = 'default'";
+    await page.getByTestId("sql-editor").fill(sql);
+    await page.getByRole("button", { name: "Run query" }).click();
+    await expect(page.getByTestId("temporary-result-count")).toHaveText("1 geometries rendered temporarily");
+    await expect(page.getByTestId("query-promotion-duplicate-policy")).toContainText(
+      "creates a new layer with new feature IDs"
+    );
+
+    await page.getByTestId("query-layer-name").fill("Road analysis");
+    await page.getByRole("button", { name: "Save as layer" }).click();
+    await expect(page.getByTestId("query-promotion-status")).toHaveText("Saved 1 features to “Road analysis”.");
+    await expect(page.getByTestId("temporary-result-count")).toHaveCount(0);
+
+    const firstExport = await exportFeatures(page);
+    expect(firstExport.features).toHaveLength(2);
+    const firstPromoted = firstExport.features.find((feature) => feature.properties.category === "road");
+    expect(firstPromoted).toBeDefined();
+    expect(firstPromoted?.properties.score).toBe(7);
+    expect(firstPromoted?.workbench.style).toMatchObject({ strokeColor: "#ec4899", strokeWidth: 5 });
+    const firstLayer = firstExport.workbench.layers.find((layer) => layer.name === "Road analysis");
+    expect(firstLayer).toBeDefined();
+    expect(firstPromoted?.workbench.layerId).toBe(firstLayer?.id);
+
+    await page.getByRole("button", { name: "Refresh" }).click();
+    expect(await exportFeatureCount(page)).toBe(2);
+    await page.reload();
+    await expect(page.getByTestId("loading-overlay")).toBeHidden({ timeout: 30_000 });
+    const reloadedExport = await exportFeatures(page);
+    expect(reloadedExport.features.find((feature) => feature.properties.category === "road")?.properties.score).toBe(7);
+
+    await page.getByTestId("sql-editor").fill(sql);
+    await page.getByRole("button", { name: "Run query" }).click();
+    await expect(page.getByTestId("temporary-result-count")).toHaveText("1 geometries rendered temporarily");
+    await page.getByTestId("query-layer-name").fill("Road analysis");
+    await page.getByRole("button", { name: "Save as layer" }).click();
+    await expect(page.getByTestId("query-promotion-status")).toHaveText("Saved 1 features to “Road analysis”.");
+
+    const repeatedExport = await exportFeatures(page);
+    const promotedFeatures = repeatedExport.features.filter((feature) => feature.properties.category === "road");
+    const promotedLayers = repeatedExport.workbench.layers.filter((layer) => layer.name === "Road analysis");
+    expect(promotedFeatures).toHaveLength(2);
+    expect(new Set(promotedFeatures.map((feature) => feature.id)).size).toBe(2);
+    expect(promotedLayers).toHaveLength(2);
+    expect(new Set(promotedLayers.map((layer) => layer.id)).size).toBe(2);
   });
 });

--- a/tests/e2e/query-runtime-smoke.spec.ts
+++ b/tests/e2e/query-runtime-smoke.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+test("query sandbox executes SELECT and rejects writes in a real browser", async ({ page }) => {
+  await page.goto("./");
+  await expect(page.getByTestId("loading-overlay")).toBeHidden({ timeout: 30_000 });
+
+  const result = await page.evaluate(async () => {
+    const { QueryRejectedError, createQueryRuntime } = await import("/vite-react-three/src/db/queryRuntime.ts");
+    const runtime = await createQueryRuntime({
+      features: [
+        {
+          id: "browser-feature",
+          geometry: {
+            type: "LineString",
+            coordinates: [
+              [0, 0],
+              [3, 4],
+            ],
+          },
+          properties: { source: "browser-smoke" },
+          style: { strokeColor: "#112233", strokeWidth: 2 },
+          layerId: "browser-layer",
+          createdAt: "2026-07-24T00:00:00.000Z",
+        },
+      ],
+      layers: [
+        {
+          id: "browser-layer",
+          name: "Browser",
+          visible: true,
+          order: 0,
+          createdAt: "2026-07-24T00:00:00.000Z",
+        },
+      ],
+    });
+    try {
+      const query = await runtime.execute(
+        "SELECT id, geometry_type, geometry_geojson FROM geometry_features ORDER BY feature_order"
+      );
+      let rejected = false;
+      try {
+        await runtime.execute("DELETE FROM geometry_features");
+      } catch (error) {
+        rejected = error instanceof QueryRejectedError;
+      }
+      return { query, rejected };
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  expect(result.rejected).toBe(true);
+  expect(result.query).toMatchObject({
+    status: "success",
+    rowCount: 1,
+    truncated: false,
+    rows: [
+      {
+        id: "browser-feature",
+        geometry_type: "LineString",
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary

- expose canonical geometry and layer data through read-only DuckDB query views
- add an isolated read-only SQL runtime with validation, cancellation, limits, and history
- add the PC-browser SQL workbench with tabular results and clear query states
- render supported query geometry as an ephemeral canvas result layer
- promote query results atomically into named persistent layers with fresh canonical IDs
- preserve result attributes, style, layer membership, refresh/reload behavior, and GeoJSON export
- document the browser-only product scope and keep local Backlog data out of Git

## Why

Phase 1 turns the existing drawing and persistence foundation into a browser-based DuckDB Spatial Lab. Users can draw geometry, query it with SQL, inspect rows and shapes, and explicitly save useful results without weakening the canonical feature/layer model or the Spatial/JSON fallback paths.

## Behavior

Repeated promotion intentionally creates a new named layer with new feature IDs; existing promoted layers are not overwritten. Temporary query geometry remains non-persistent until the user explicitly saves it.

## Validation

- `npm run test` — 123 tests passed
- `npm run lint`
- `npm run format:check`
- `npm run build`
- desktop Chromium E2E — 10 journeys passed
- dedicated Phase 1 journey verified draw → SQL table rows → changed WebGL canvas with temporary result shape → named layer promotion → refresh/reload → GeoJSON export → repeat save

Backlog remains local-only and is not included in this PR.