### PR TITLE
feat: add constructing geometry SQL example

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,14 +47,14 @@ Exit criteria:
 
 Goal: make DuckDB the visible center of the application.
 
-- Add a SQL editor with query execution, history, cancellation, and clear error
-  messages.
-- Expose documented read-only views for features and layers.
-- Show tabular query results alongside the canvas.
-- Render geometry returned by a query as a temporary result layer.
-- Allow a result layer to be saved as a persistent layer.
-- Include runnable examples for filtering, measuring, constructing, and
-  converting geometry.
+- [x] Add a SQL editor with query execution, history, cancellation, and clear error
+      messages.
+- [x] Expose documented read-only views for features and layers.
+- [x] Show tabular query results alongside the canvas.
+- [x] Render geometry returned by a query as a temporary result layer.
+- [x] Allow a result layer to be saved as a persistent layer.
+- [x] Include runnable examples for filtering, measuring, constructing, and
+      converting geometry.
 
 Exit criteria:
 
@@ -152,9 +152,9 @@ they directly support a spatial-analysis workflow.
 1. [x] Complete the canonical feature and layer schema.
 2. [x] Add automated tests around geometry persistence and GeoJSON round-trips.
 3. [x] Complete Phase 0 browser workflow coverage.
-4. [ ] Build the SQL editor and tabular result view.
-5. [ ] Render query geometry as a temporary layer.
-6. [ ] Promote query results to persistent layers.
+4. [x] Build the SQL editor and tabular result view.
+5. [x] Render query geometry as a temporary layer.
+6. [x] Promote query results to persistent layers.
 7. [ ] Build the layer panel and synchronized selection.
 
 The first major product milestone is complete when a user can draw or import
@@ -179,6 +179,15 @@ save or export the result entirely in the browser.
 The canonical persistence implementation was merged in PR #36. Phase 0 browser
 workflow coverage was completed on 2026-07-19, including a fix that maps primary
 pointer dragging to Pan instead of the disabled Rotate action.
+
+### Completed on 2026-08-25
+
+- Completed Phase 1 with read-only SQL views and runtime, the SQL editor and
+  tabular results, temporary geometry rendering, persistent layer promotion,
+  and runnable filtering, measuring, constructing, and converting examples.
+- Verified the constructing example in desktop Chromium: its row and geometry
+  result are visible, while persistent features and layers remain unchanged
+  until an explicit save.
 
 ## Today: 2026-07-19
 
@@ -219,13 +228,13 @@ Verification completed on 2026-07-19:
 
 ### Next if the Phase 0 checks are green
 
-- [ ] Draft the SQL editor and tabular result-view design.
-- [ ] Put system invariants before the task list, including read-only query
+- [x] Draft the SQL editor and tabular result-view design.
+- [x] Put system invariants before the task list, including read-only query
       boundaries, result-size limits, cancellation behavior, and the rule that
       query results do not mutate persistent features implicitly.
-- [ ] Add a failure matrix covering invalid SQL, long-running and cancelled
+- [x] Add a failure matrix covering invalid SQL, long-running and cancelled
       queries, empty and large results, geometry/non-geometry columns,
       Spatial/JSON stores, and component unmount or database restart.
-- [ ] Define the smallest vertical slice: execute read-only SQL against
+- [x] Define the smallest vertical slice: execute read-only SQL against
       documented feature/layer views and display tabular results. Temporary
       geometry rendering remains the following milestone.

--- a/src/hooks/useQueryWorkbench.ts
+++ b/src/hooks/useQueryWorkbench.ts
@@ -16,6 +16,10 @@ export const SQL_EXAMPLES = [
     sql: "SELECT id, ST_Length(ST_GeomFromGeoJSON(geometry_geojson)) AS length FROM geometry_features",
   },
   {
+    label: "Construct geometry",
+    sql: "SELECT 'constructed-line' AS name, ST_AsGeoJSON(ST_GeomFromText('LINESTRING (100 100, 300 200)')) AS geometry_geojson",
+  },
+  {
     label: "Convert geometry",
     sql: "SELECT id, ST_AsText(ST_GeomFromGeoJSON(geometry_geojson)) AS geometry_wkt FROM geometry_features",
   },

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -312,6 +312,7 @@ test.describe("drawing workspace", () => {
     ]);
 
     const canvas = page.getByTestId("drawing-canvas");
+    const persistentBeforeQuery = await exportFeatures(page);
     const canvasBeforeQuery = await canvas.screenshot();
     await examples.selectOption({ label: "Construct geometry" });
     await expect(page.getByTestId("sql-editor")).toContainText("ST_GeomFromText");
@@ -323,12 +324,16 @@ test.describe("drawing workspace", () => {
     await expect(page.getByTestId("temporary-result-count")).toHaveText("1 geometries rendered temporarily");
     await expect(page.locator('tr[data-query-geometry="rendered"]')).toHaveCount(1);
     expect((await canvas.screenshot()).equals(canvasBeforeQuery)).toBe(false);
-    expect(await exportFeatureCount(page)).toBe(0);
+    const persistentAfterQuery = await exportFeatures(page);
+    expect(persistentAfterQuery.features).toEqual(persistentBeforeQuery.features);
+    expect(persistentAfterQuery.workbench.layers).toEqual(persistentBeforeQuery.workbench.layers);
 
     await page.reload();
     await expect(page.getByTestId("loading-overlay")).toBeHidden({ timeout: 30_000 });
     await expect(page.getByTestId("temporary-result-count")).toHaveCount(0);
-    expect(await exportFeatureCount(page)).toBe(0);
+    const persistentAfterReload = await exportFeatures(page);
+    expect(persistentAfterReload.features).toEqual(persistentBeforeQuery.features);
+    expect(persistentAfterReload.workbench.layers).toEqual(persistentBeforeQuery.workbench.layers);
   });
 
   test("query resultを名前付きlayerへ保存しattributesをreload後も保持する", async ({ page }) => {

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -297,6 +297,40 @@ test.describe("drawing workspace", () => {
     await expect(page.getByTestId("temporary-result-count")).toHaveCount(0);
   });
 
+  test("Examplesのconstructing SQLをtableとtemporary layerへ表示し永続化しない", async ({ page }) => {
+    test.setTimeout(120_000);
+    await gotoApp(page);
+    await page.getByRole("button", { name: "Clear" }).click();
+
+    const examples = page.locator("#sql-examples");
+    await expect(examples.locator("option")).toHaveText([
+      "Select an example",
+      "Filter features",
+      "Measure geometry",
+      "Construct geometry",
+      "Convert geometry",
+    ]);
+
+    const canvas = page.getByTestId("drawing-canvas");
+    const canvasBeforeQuery = await canvas.screenshot();
+    await examples.selectOption({ label: "Construct geometry" });
+    await expect(page.getByTestId("sql-editor")).toContainText("ST_GeomFromText");
+    await page.getByRole("button", { name: "Run query" }).click();
+
+    await expect(page.getByTestId("query-status")).toHaveText("success", { timeout: 30_000 });
+    await expect(page.getByRole("table")).toContainText("constructed-line");
+    await expect(page.getByRole("table")).toContainText("LineString");
+    await expect(page.getByTestId("temporary-result-count")).toHaveText("1 geometries rendered temporarily");
+    await expect(page.locator('tr[data-query-geometry="rendered"]')).toHaveCount(1);
+    expect((await canvas.screenshot()).equals(canvasBeforeQuery)).toBe(false);
+    expect(await exportFeatureCount(page)).toBe(0);
+
+    await page.reload();
+    await expect(page.getByTestId("loading-overlay")).toBeHidden({ timeout: 30_000 });
+    await expect(page.getByTestId("temporary-result-count")).toHaveCount(0);
+    expect(await exportFeatureCount(page)).toBe(0);
+  });
+
   test("query resultを名前付きlayerへ保存しattributesをreload後も保持する", async ({ page }) => {
     test.setTimeout(150_000);
     await gotoApp(page);


### PR DESCRIPTION
## Summary
- add a runnable DuckDB Spatial geometry-construction example
- render its GeoJSON result in the table and temporary canvas layer
- mark Phase 1 complete in the roadmap

## Verification
- npm run format:check
- npm run lint
- npm run build
- desktop Chromium Playwright: constructing SQL example passed

Closes TASK-1.7